### PR TITLE
Clean up ArrowErrorSet() usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   src/geoarrow/kernel.c
   src/geoarrow/builder.c
   src/geoarrow/array_view.c
+  src/geoarrow/util.c
   src/geoarrow/visitor.c
   src/geoarrow/wkb_reader.c
   src/geoarrow/wkb_writer.c
@@ -130,6 +131,7 @@ if(GEOARROW_BUILD_TESTS)
   add_executable(metadata_test src/geoarrow/metadata_test.cc)
   add_executable(kernel_test src/geoarrow/kernel_test.cc)
   add_executable(visitor_test src/geoarrow/visitor_test.cc)
+  add_executable(util_test src/geoarrow/util_test.cc)
   add_executable(wkb_reader_test src/geoarrow/wkb_reader_test.cc)
   add_executable(wkb_writer_test src/geoarrow/wkb_writer_test.cc)
   add_executable(wkt_reader_test src/geoarrow/wkt_reader_test.cc)
@@ -152,6 +154,7 @@ if(GEOARROW_BUILD_TESTS)
   target_link_libraries(kernel_test geoarrow gtest_main)
   target_link_libraries(metadata_test geoarrow gtest_main)
   target_link_libraries(visitor_test geoarrow gtest_main)
+  target_link_libraries(util_test geoarrow gtest_main)
   target_link_libraries(wkb_reader_test geoarrow gtest_main)
   target_link_libraries(wkb_writer_test geoarrow gtest_main)
   target_link_libraries(wkt_reader_test geoarrow gtest_main)
@@ -169,6 +172,7 @@ if(GEOARROW_BUILD_TESTS)
   gtest_discover_tests(kernel_test)
   gtest_discover_tests(metadata_test)
   gtest_discover_tests(visitor_test)
+  gtest_discover_tests(util_test)
   gtest_discover_tests(wkb_reader_test)
   gtest_discover_tests(wkb_writer_test)
   gtest_discover_tests(wkt_reader_test)

--- a/src/geoarrow/array_view.c
+++ b/src/geoarrow/array_view.c
@@ -25,8 +25,7 @@ static int GeoArrowArrayViewInitInternal(struct GeoArrowArrayView* array_view,
       array_view->n_offsets = 3;
       break;
     default:
-      ArrowErrorSet((struct ArrowError*)error,
-                    "Unsupported geometry type in GeoArrowArrayViewInit()");
+      GeoArrowErrorSet(error, "Unsupported geometry type in GeoArrowArrayViewInit()");
       return EINVAL;
   }
 
@@ -49,8 +48,7 @@ static int GeoArrowArrayViewInitInternal(struct GeoArrowArrayView* array_view,
       array_view->coords.n_values = 4;
       break;
     default:
-      ArrowErrorSet((struct ArrowError*)error,
-                    "Unsupported dimensions in GeoArrowArrayViewInit()");
+      GeoArrowErrorSet(error, "Unsupported dimensions in GeoArrowArrayViewInit()");
       return EINVAL;
   }
 
@@ -62,8 +60,7 @@ static int GeoArrowArrayViewInitInternal(struct GeoArrowArrayView* array_view,
       array_view->coords.coords_stride = array_view->coords.n_values;
       break;
     default:
-      ArrowErrorSet((struct ArrowError*)error,
-                    "Unsupported coord type in GeoArrowArrayViewInit()");
+      GeoArrowErrorSet(error, "Unsupported coord type in GeoArrowArrayViewInit()");
       return EINVAL;
   }
 
@@ -105,9 +102,9 @@ static int GeoArrowArrayViewSetArrayInternal(struct GeoArrowArrayView* array_vie
     switch (array_view->schema_view.coord_type) {
       case GEOARROW_COORD_TYPE_SEPARATE:
         if (array->n_children != array_view->coords.n_values) {
-          ArrowErrorSet((struct ArrowError*)error,
-                        "Unexpected number of children for struct coordinate array "
-                        "in GeoArrowArrayViewSetArray()");
+          GeoArrowErrorSet(error,
+                           "Unexpected number of children for struct coordinate array "
+                           "in GeoArrowArrayViewSetArray()");
           return EINVAL;
         }
 
@@ -128,9 +125,10 @@ static int GeoArrowArrayViewSetArrayInternal(struct GeoArrowArrayView* array_vie
 
       case GEOARROW_COORD_TYPE_INTERLEAVED:
         if (array->n_children != 1) {
-          ArrowErrorSet((struct ArrowError*)error,
-                        "Unexpected number of children for interleaved coordinate array "
-                        "in GeoArrowArrayViewSetArray()");
+          GeoArrowErrorSet(
+              error,
+              "Unexpected number of children for interleaved coordinate array "
+              "in GeoArrowArrayViewSetArray()");
           return EINVAL;
         }
 
@@ -151,8 +149,7 @@ static int GeoArrowArrayViewSetArrayInternal(struct GeoArrowArrayView* array_vie
         break;
 
       default:
-        ArrowErrorSet((struct ArrowError*)error,
-                      "Unexpected coordinate type GeoArrowArrayViewSetArray()");
+        GeoArrowErrorSet(error, "Unexpected coordinate type GeoArrowArrayViewSetArray()");
         return EINVAL;
     }
 

--- a/src/geoarrow/builder.c
+++ b/src/geoarrow/builder.c
@@ -514,8 +514,7 @@ static int feat_end_point(struct GeoArrowVisitor* v) {
     private->empty_coord.n_values = n_dim;
     NANOARROW_RETURN_NOT_OK(coords_point(v, &private->empty_coord));
   } else if (private->size[0] != 1) {
-    ArrowErrorSet((struct ArrowError*)v->error,
-                  "Can't convert feature with >1 coordinate to POINT");
+    GeoArrowErrorSet(v->error, "Can't convert feature with >1 coordinate to POINT");
     return EINVAL;
   }
 
@@ -665,8 +664,7 @@ static int feat_end_multipoint(struct GeoArrowVisitor* v) {
     int32_t n_coord32 = (int32_t)builder->view.coords.size_coords;
     NANOARROW_RETURN_NOT_OK(GeoArrowBuilderOffsetAppend(builder, 0, &n_coord32, 1));
   } else if (private->size[0] != 1) {
-    ArrowErrorSet((struct ArrowError*)v->error,
-                  "Can't convert feature with >1 sequence to LINESTRING");
+    GeoArrowErrorSet(v->error, "Can't convert feature with >1 sequence to LINESTRING");
     return EINVAL;
   }
 

--- a/src/geoarrow/geoarrow.h
+++ b/src/geoarrow/geoarrow.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+GeoArrowErrorCode GeoArrowErrorSet(struct GeoArrowError* error, const char* fmt, ...);
+
 GeoArrowErrorCode GeoArrowSchemaInit(struct ArrowSchema* schema, enum GeoArrowType type);
 
 GeoArrowErrorCode GeoArrowSchemaInitExtension(struct ArrowSchema* schema,

--- a/src/geoarrow/kernel.c
+++ b/src/geoarrow/kernel.c
@@ -122,7 +122,7 @@ static int kernel_get_arg_long(const char* options, const char* key, long* out,
   type_str.size_bytes = 0;
   NANOARROW_RETURN_NOT_OK(ArrowMetadataGetValue(options, ArrowCharView(key), &type_str));
   if (type_str.data == NULL && required) {
-    ArrowErrorSet((struct ArrowError*)error, "Missing required parameter '%s'", key);
+    GeoArrowErrorSet(error, "Missing required parameter '%s'", key);
     return EINVAL;
   } else if (type_str.data == NULL && !required) {
     return NANOARROW_OK;

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -292,9 +292,8 @@ static GeoArrowErrorCode GeoArrowMetadataViewInitJSON(
   SkipWhitespace(&s);
 
   if (ParseJSONMetadata(metadata_view, &s) != GEOARROW_OK) {
-    ArrowErrorSet((struct ArrowError*)error,
-                  "Expected valid GeoArrow JSON metadata but got '%.*s'",
-                  (int)metadata.size_bytes, metadata.data);
+    GeoArrowErrorSet(error, "Expected valid GeoArrow JSON metadata but got '%.*s'",
+                     (int)metadata.size_bytes, metadata.data);
     return EINVAL;
   }
 

--- a/src/geoarrow/util.c
+++ b/src/geoarrow/util.c
@@ -1,0 +1,36 @@
+
+#include <stdarg.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "geoarrow.h"
+
+GeoArrowErrorCode GeoArrowErrorSet(struct GeoArrowError* error, const char* fmt, ...) {
+  if (error == NULL) {
+    return GEOARROW_OK;
+  }
+
+  memset(error->message, 0, sizeof(error->message));
+
+  va_list args;
+  va_start(args, fmt);
+  int chars_needed = vsnprintf(error->message, sizeof(error->message), fmt, args);
+  va_end(args);
+
+  if (chars_needed < 0) {
+    return EINVAL;
+  } else if (((size_t)chars_needed) >= sizeof(error->message)) {
+    return ERANGE;
+  } else {
+    return GEOARROW_OK;
+  }
+}
+
+const char* GeoArrowErrorMessage(struct GeoArrowError* error) {
+  if (error == NULL) {
+    return "";
+  } else {
+    return error->message;
+  }
+}

--- a/src/geoarrow/util_test.cc
+++ b/src/geoarrow/util_test.cc
@@ -1,0 +1,26 @@
+
+#include <gtest/gtest.h>
+
+#include "geoarrow.h"
+
+TEST(GeoArrowErrorTest, ErrorTestSet) {
+  struct GeoArrowError error;
+  EXPECT_EQ(GeoArrowErrorSet(&error, "there were %d foxes", 4), GEOARROW_OK);
+  EXPECT_STREQ(error.message, "there were 4 foxes");
+}
+
+TEST(GeoArrowErrorTest, ErrorTestSetOverrun) {
+  struct GeoArrowError error;
+  char big_error[2048];
+  const char* a_few_chars = "abcdefg";
+  for (int i = 0; i < 2047; i++) {
+    big_error[i] = a_few_chars[i % strlen(a_few_chars)];
+  }
+  big_error[2047] = '\0';
+
+  EXPECT_EQ(GeoArrowErrorSet(&error, "%s", big_error), ERANGE);
+  EXPECT_EQ(std::string(error.message), std::string(big_error, 1023));
+
+  wchar_t bad_string[] = {0xFFFF, 0};
+  EXPECT_EQ(GeoArrowErrorSet(&error, "%ls", bad_string), EINVAL);
+}

--- a/src/geoarrow/wkb_reader.c
+++ b/src/geoarrow/wkb_reader.c
@@ -52,9 +52,8 @@ static inline int WKBReaderReadEndian(struct WKBReaderPrivate* s,
     s->size_bytes--;
     return GEOARROW_OK;
   } else {
-    ArrowErrorSet((struct ArrowError*)error,
-                  "Expected endian byte but found end of buffer at byte %ld",
-                  (long)(s->data - s->data0));
+    GeoArrowErrorSet(error, "Expected endian byte but found end of buffer at byte %ld",
+                     (long)(s->data - s->data0));
     return EINVAL;
   }
 }
@@ -70,9 +69,8 @@ static inline int WKBReaderReadUInt32(struct WKBReaderPrivate* s, uint32_t* out,
     }
     return GEOARROW_OK;
   } else {
-    ArrowErrorSet((struct ArrowError*)error,
-                  "Expected uint32 but found end of buffer at byte %ld",
-                  (long)(s->data - s->data0));
+    GeoArrowErrorSet(error, "Expected uint32 but found end of buffer at byte %ld",
+                     (long)(s->data - s->data0));
     return EINVAL;
   }
 }

--- a/src/geoarrow/wkb_reader.c
+++ b/src/geoarrow/wkb_reader.c
@@ -210,9 +210,9 @@ static int WKBReaderReadGeometry(struct WKBReaderPrivate* s, struct GeoArrowVisi
       }
       break;
     default:
-      ArrowErrorSet((struct ArrowError*)v->error,
-                    "Expected valid geometry type code but found %u at byte %ld",
-                    (unsigned int)geometry_type, (long)(data_at_geom_type - s->data0));
+      GeoArrowErrorSet(v->error,
+                       "Expected valid geometry type code but found %u at byte %ld",
+                       (unsigned int)geometry_type, (long)(data_at_geom_type - s->data0));
       return EINVAL;
   }
 

--- a/src/geoarrow/wkt_reader.c
+++ b/src/geoarrow/wkt_reader.c
@@ -499,8 +499,7 @@ static inline int ReadTaggedGeometry(struct WKTReaderPrivate* s,
       NANOARROW_RETURN_NOT_OK(ReadGeometryCollection(s, v));
       break;
     default:
-      ArrowErrorSet((struct ArrowError*)v->error,
-                    "Internal error: unrecognized geometry type id");
+      GeoArrowErrorSet(v->error, "Internal error: unrecognized geometry type id");
       return EINVAL;
   }
 

--- a/src/geoarrow/wkt_reader.c
+++ b/src/geoarrow/wkt_reader.c
@@ -101,7 +101,7 @@ static inline void SetParseErrorAuto(const char* expected, struct WKTReaderPriva
                                      struct GeoArrowError* error) {
   long pos = s->data - s->data0;
   // TODO: "but found ..." from s
-  ArrowErrorSet((struct ArrowError*)error, "Expected %s at byte %ld", expected, pos);
+  GeoArrowErrorSet(error, "Expected %s at byte %ld", expected, pos);
 }
 
 static inline int AssertChar(struct WKTReaderPrivate* s, char c,

--- a/src/geoarrow/wkt_writer.c
+++ b/src/geoarrow/wkt_writer.c
@@ -90,8 +90,7 @@ static int geom_start_wkt(struct GeoArrowVisitor* v,
                                  GEOARROW_GEOMETRY_TYPE_GEOMETRYCOLLECTION) {
     const char* geometry_type_name = GeoArrowGeometryTypeString(geometry_type);
     if (geometry_type_name == NULL) {
-      ArrowErrorSet((struct ArrowError*)v->error,
-                    "WKTWriter::geom_start(): Unexpected `geometry_type`");
+      GeoArrowErrorSet(v->error, "WKTWriter::geom_start(): Unexpected `geometry_type`");
       return EINVAL;
     }
 
@@ -110,8 +109,7 @@ static int geom_start_wkt(struct GeoArrowVisitor* v,
         NANOARROW_RETURN_NOT_OK(WKTWriterWrite(private, " ZM"));
         break;
       default:
-        ArrowErrorSet((struct ArrowError*)v->error,
-                      "WKTWriter::geom_start(): Unexpected `dimensions`");
+        GeoArrowErrorSet(v->error, "WKTWriter::geom_start(): Unexpected `dimensions`");
         return EINVAL;
     }
 


### PR DESCRIPTION
Provide our own GeoArrowErrorSet() for GeoArrowError to minimize the number of times we have to cast between error types.