### PR TITLE
Add `point_coords()` to Python bindings

### DIFF
--- a/python/geoarrow/pyarrow/__init__.py
+++ b/python/geoarrow/pyarrow/__init__.py
@@ -56,7 +56,7 @@ from ._compute import (
     with_edge_type,
     with_geometry_type,
     rechunk,
-    point_coords
+    point_coords,
 )
 
 register_extension_types()

--- a/python/geoarrow/pyarrow/__init__.py
+++ b/python/geoarrow/pyarrow/__init__.py
@@ -55,7 +55,8 @@ from ._compute import (
     with_dimensions,
     with_edge_type,
     with_geometry_type,
-    rechunk
+    rechunk,
+    point_coords
 )
 
 register_extension_types()

--- a/python/tests/test_geoarrow_pyarrow_compute.py
+++ b/python/tests/test_geoarrow_pyarrow_compute.py
@@ -1,3 +1,5 @@
+import math
+
 import pyarrow as pa
 import pytest
 
@@ -315,3 +317,19 @@ def test_with_geometry_type():
 
     point2 = _compute.with_geometry_type(multipoint2, ga.GeometryType.POINT)
     assert point2 == point
+
+
+def test_point_coords():
+    x, y = _compute.point_coords(["POINT (0 1)", "POINT (2 3)"])
+    assert x == pa.array([0.0, 2.0])
+    assert y == pa.array([1.0, 3.0])
+
+    x, y, z = _compute.point_coords(["POINT (0 1)", "POINT (2 3)"], ga.Dimensions.XYZ)
+    assert x == pa.array([0.0, 2.0])
+    assert y == pa.array([1.0, 3.0])
+    assert all(math.isnan(el.as_py()) for el in z)
+
+    chunked = pa.chunked_array([ga.as_wkt(["POINT (0 1)", "POINT (2 3)"])])
+    x, y = _compute.point_coords(chunked)
+    assert x == pa.chunked_array([pa.array([0.0, 2.0])])
+    assert y == pa.chunked_array([pa.array([1.0, 3.0])])


### PR DESCRIPTION
Sometimes you just need x and y!

```
>>> import geoarrow.pyarrow as ga
>>> x, y = ga.point_coords(["POINT (0 1)", "POINT (2 3)"])
>>> list(x)
[<pyarrow.DoubleScalar: 0.0>, <pyarrow.DoubleScalar: 2.0>]
>>> list(y)
[<pyarrow.DoubleScalar: 1.0>, <pyarrow.DoubleScalar: 3.0>]
```