### PR TITLE
Sketch pandas integration

### DIFF
--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -90,7 +90,7 @@ class GeoArrowAccessor:
         return self._wrap_series(_ga.with_crs(self._obj, crs=crs, crs_type=crs_type))
 
     def with_dimensions(self, dimensions):
-        return self.with_dimensions(_ga.with_coord_type(self._obj, dimensions))
+        return self._wrap_series(_ga.with_dimensions(self._obj, dimensions))
 
     def with_geometry_type(self, geometry_type):
         return self.with_geometry_type(_ga.with_coord_type(self._obj, geometry_type))

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -129,7 +129,7 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
         if len(items) == 1:
             return items[0]
 
-        types = [item.type for item in to_concat]
+        types = [item._data.type for item in to_concat]
         common_type = _ga.vector_type_common(types)
 
         chunks = []

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -73,9 +73,9 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
 
     def __getitem__(self, item):
         if isinstance(item, int):
-            return GeoArrowExtensionScalar(self._parent, item)
+            return GeoArrowExtensionScalar(self._data, item)
         elif isinstance(item, slice):
-            return GeoArrowExtensionArray(self._data[slice])
+            return GeoArrowExtensionArray(self._data[item])
         elif isinstance(item, list):
             return GeoArrowExtensionArray(self._data[_pa.array(item)])
         else:
@@ -85,7 +85,11 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
         return len(self._data)
 
     def __eq__(self, other):
-        array = _pa.array(item == other_item for item, other_item in zip(self, other))
+        if isinstance(other, GeoArrowExtensionScalar):
+            array = _pa.array(item == other for item in self)
+        else:
+            array = _pa.array(item == other_item for item, other_item in zip(self, other))
+
         return array.to_numpy(zero_copy_only=False)
 
     @property

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -140,6 +140,7 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
     def dtype(self):
         return self._dtype
 
+    @property
     def nbytes(self):
         return self._data.nbytes
 

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,5 +1,4 @@
 import re
-import numpy as np
 import pandas as _pd
 import pyarrow as _pa
 import numpy as _np

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,6 +1,50 @@
 import pandas as _pd
 import pyarrow as _pa
+from . import lib
 from . import pyarrow as _ga
+
+
+class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
+    def __init__(self, parent):
+        if isinstance(parent, _ga.VectorType):
+            self._parent = parent._type
+        elif isinstance(parent, lib.CVectorType):
+            self._parent = parent
+        elif isinstance(parent, GeoArrowExtensionDtype):
+            self._parent = parent._parent
+        else:
+            raise TypeError(
+                "`geoarrow_type` must inherit from geoarrow.pyarrow.VectorType"
+            )
+
+    @classmethod
+    def construct_array_type(cls):
+        pass
+
+    @classmethod
+    def construct_from_string(cls, string):
+        raise NotImplementedError()
+
+    def __repr__(self):
+        return f"{type(self).__name__}({repr(self._parent)})"
+
+    def __str__(self):
+        ext_name = self._parent.extension_name
+        ext_meta = self._parent.extension_metadata.decode("UTF-8")
+        if ext_meta == "{}":
+            return f"{ext_name}"
+        else:
+            return f"{ext_name}[{ext_meta}]"
+
+    def __hash__(self):
+        return hash(str(self))
+
+    @property
+    def name(self):
+        return str(self)
+
+    def __from_arrow__(self, array):
+        raise NotImplementedError()
 
 
 @_pd.api.extensions.register_series_accessor("geoarrow")

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -37,6 +37,9 @@ class GeoArrowExtensionScalar(bytes):
         else:
             return super().__new__(cls, bytes_value)
 
+    def __hash__(self) -> int:
+        return super().__hash__()
+
     def __str__(self):
         return self.wkt
 
@@ -112,6 +115,13 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
             raise IndexError(
                 "only integers, slices (`:`), ellipsis (`...`), numpy.newaxis (`None`) and integer or boolean arrays are valid indices"
             )
+
+    def __contains__(self, item: object):
+        for scalar in self:
+            if scalar == item:
+                return True
+
+        return False
 
     def __len__(self):
         return len(self._data)
@@ -205,12 +215,15 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
         )
 
     def to_numpy(self, dtype=None, copy=False, na_value=None):
-        if dtype is not None and dtype is not object:
+        if dtype is not None and dtype is not object and dtype != "O":
             raise TypeError("to_numpy() with dtype != None not supported")
         if na_value is not None:
             raise TypeError("to_numpy() with na_value != None not supported")
 
-        return _np.array(self, dtype=object)
+        return _np.array(list(self), dtype=object)
+
+    def __array__(self, dtype=None):
+        return self.to_numpy(dtype=dtype)
 
 
 @_pd.api.extensions.register_extension_dtype

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pandas as _pd
 import pyarrow as _pa
 from . import lib

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -8,7 +8,8 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
     def __init__(self, obj, type=None):
         if type is not None:
             self._dtype = GeoArrowExtensionDtype(type)
-            self._parent = _ga.array(obj, _ga.VectorType(self._dtype._parent))
+            arrow_type = _ga.VectorType._from_ctype(self._dtype._parent)
+            self._parent = _ga.array(obj, arrow_type)
         else:
             self._parent = _ga.array(obj)
             self._dtype = GeoArrowExtensionDtype(self._parent.type)
@@ -61,6 +62,9 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
             return out.to_numpy()
         else:
             return out.to_numpy(zero_copy_only=False)
+
+    def __repr__(self):
+        return repr(self._parent)
 
 
 class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -475,3 +475,7 @@ class GeoArrowAccessor:
     def point_coords(self, dimensions=None):
         point_coords = _ga.point_coords(_ga.with_coord_type(self._obj, dimensions))
         return tuple(_pd.Series(dim, index=self._obj.index) for dim in point_coords)
+
+    def to_geopandas(self):
+        import geopandas
+        return geopandas.GeoSeries.from_wkb(self.as_wkb().geoarrow.format_wkb())

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -473,4 +473,5 @@ class GeoArrowAccessor:
         return self.with_geometry_type(_ga.with_coord_type(self._obj, geometry_type))
 
     def point_coords(self, dimensions=None):
-        return self.point_coords(_ga.with_coord_type(self._obj, dimensions))
+        point_coords = _ga.point_coords(_ga.with_coord_type(self._obj, dimensions))
+        return tuple(_pd.Series(dim, index=self._obj.index) for dim in point_coords)

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -197,11 +197,31 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
 
     def __str__(self):
         ext_name = self._parent.extension_name
+        ext_dims = self._parent.dimensions
+        ext_coord = self._parent.coord_type
         ext_meta = self._parent.extension_metadata.decode("UTF-8")
-        if ext_meta == "{}":
-            return f"{ext_name}"
+
+        if ext_dims == _ga.Dimensions.XYZ:
+            dims_str = "[Z]"
+        elif ext_dims == _ga.Dimensions.XYM:
+            dims_str = "[M]"
+        elif ext_dims == _ga.Dimensions.XYZM:
+            dims_str = "[ZM]"
         else:
-            return f"{ext_name}[{ext_meta}]"
+            dims_str = ""
+
+        if ext_coord == _ga.CoordType.INTERLEAVED:
+            coord_str = "[interleaved]"
+        else:
+            coord_str = ""
+
+        if ext_meta == "{}":
+            meta_str = ""
+        else:
+            meta_str = f"[{ext_meta}]"
+
+
+        return f"{ext_name}{dims_str}{coord_str}{meta_str}"
 
     def __hash__(self):
         return hash(str(self))

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import pyarrow as pa
+from . import pyarrow as ga
+
+
+@pd.api.extensions.register_series_accessor("geoarrow")
+class GeoArrowAccessor:
+    def __init__(self, pandas_obj):
+        self._obj = pandas_obj
+
+    def as_geoarrow(self, type=None, coord_type=None):
+        array_or_chunked = ga.as_geoarrow(self._obj, type=type, coord_type=coord_type)
+        return pd.Series(
+            array_or_chunked,
+            index=self._obj.index,
+            dtype=pd.ArrowDtype(array_or_chunked.type),
+        )

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,4 +1,5 @@
 import re
+import numpy as np
 import pandas as _pd
 import pyarrow as _pa
 import numpy as _np

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -4,6 +4,30 @@ from . import lib
 from . import pyarrow as _ga
 
 
+class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
+    def __getitem__(self, item):
+        raise NotImplementedError()
+
+    def __len__(self):
+        raise NotImplementedError()
+
+    def __contains__(self, item):
+        raise NotImplementedError()
+
+    def __eq__(self, other):
+        raise NotImplementedError()
+
+    def to_numpy(self, dtype, copy=False, na_value=None):
+        raise NotImplementedError()
+
+    @property
+    def dtype(self):
+        raise NotImplementedError()
+
+    def isna(self):
+        raise NotImplementedError()
+
+
 class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
     def __init__(self, parent):
         if isinstance(parent, _ga.VectorType):
@@ -16,6 +40,10 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
             raise TypeError(
                 "`geoarrow_type` must inherit from geoarrow.pyarrow.VectorType"
             )
+
+    @property
+    def type(self):
+        raise NotImplementedError()
 
     @classmethod
     def construct_array_type(cls):

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,4 +1,4 @@
-import re
+import re as _re
 import pandas as _pd
 import pyarrow as _pa
 import numpy as _np
@@ -228,10 +228,10 @@ class GeoArrowExtensionArray(_pd.api.extensions.ExtensionArray):
 
 @_pd.api.extensions.register_extension_dtype
 class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
-    _match = re.compile(
+    _match = _re.compile(
         r"^geoarrow."
         r"(?P<type>wkt|wkb|point|linestring|polygon|multipoint|multilinestring|multipolygon)"
-        r"(?P<dims>\[Z\]|\[M\]|\[ZM\])?"
+        r"(?P<dims>\[z\]|\[m\]|\[zm\])?"
         r"(?P<coord_type>\[interleaved\])?"
         r"(?P<metadata>.*)$"
     )
@@ -276,11 +276,11 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
 
         params = matched.groupdict()
 
-        if params["dims"] == "[Z]":
+        if params["dims"] == "[z]":
             dims = _ga.Dimensions.XYZ
-        elif params["dims"] == "[M]":
+        elif params["dims"] == "[m]":
             dims = _ga.Dimensions.XYM
-        elif params["dims"] == "[ZM]":
+        elif params["dims"] == "[zm]":
             dims = _ga.Dimensions.XYZM
         elif params["type"] in ("wkt", "wkb"):
             dims = _ga.Dimensions.UNKNOWN
@@ -338,11 +338,11 @@ class GeoArrowExtensionDtype(_pd.api.extensions.ExtensionDtype):
         ext_meta = self._parent.extension_metadata.decode("UTF-8")
 
         if ext_dims == _ga.Dimensions.XYZ:
-            dims_str = "[Z]"
+            dims_str = "[z]"
         elif ext_dims == _ga.Dimensions.XYM:
-            dims_str = "[M]"
+            dims_str = "[m]"
         elif ext_dims == _ga.Dimensions.XYZM:
-            dims_str = "[ZM]"
+            dims_str = "[zm]"
         else:
             dims_str = ""
 

--- a/python/geoarrow/pandas.py
+++ b/python/geoarrow/pandas.py
@@ -1,17 +1,99 @@
-import pandas as pd
-import pyarrow as pa
-from . import pyarrow as ga
+import pandas as _pd
+import pyarrow as _pa
+from . import pyarrow as _ga
 
 
-@pd.api.extensions.register_series_accessor("geoarrow")
+@_pd.api.extensions.register_series_accessor("geoarrow")
 class GeoArrowAccessor:
     def __init__(self, pandas_obj):
         self._obj = pandas_obj
 
-    def as_geoarrow(self, type=None, coord_type=None):
-        array_or_chunked = ga.as_geoarrow(self._obj, type=type, coord_type=coord_type)
-        return pd.Series(
+    def _wrap_series(self, array_or_chunked):
+        return _pd.Series(
             array_or_chunked,
             index=self._obj.index,
-            dtype=pd.ArrowDtype(array_or_chunked.type),
+            dtype=_pd.ArrowDtype(array_or_chunked.type),
         )
+
+    def _obj_is_geoarrow(self):
+        return isinstance(self._obj.dtype, _pd.ArrowDtype) and isinstance(
+            self._obj.dtype.pyarrow_dtype, _ga.VectorType
+        )
+
+    def parse_all(self):
+        _ga.parse_all(self._obj)
+        return self._obj
+
+    def as_wkt(self):
+        return self._wrap_series(_ga.as_wkt(self._obj))
+
+    def as_wkb(self):
+        return self._wrap_series(_ga.as_wkb(self._obj))
+
+    def format_wkt(self, significant_digits=None, max_element_size_bytes=None):
+        if not self._obj_is_geoarrow():
+            raise TypeError("Can't format_wkt() a non-geoarrow Series")
+
+        array_or_chunked = _ga.format_wkt(
+            _pa.array(self._obj),
+            significant_digits=significant_digits,
+            max_element_size_bytes=max_element_size_bytes,
+        )
+        return self._wrap_series(array_or_chunked)
+
+    def format_wkb(self):
+        if not self._obj_is_geoarrow():
+            raise TypeError("Can't format_wkb() a non-geoarrow Series")
+
+        array_or_chunked = _ga.as_wkb(_pa.array(self._obj))
+        if isinstance(array_or_chunked, _pa.ChunkedArray):
+            storage = [chunk.storage for chunk in array_or_chunked.chunks]
+            return self._wrap_series(_pa.chunked_array(storage, _pa.binary()))
+        else:
+            return self._wrap_series(array_or_chunked.storage)
+
+    def as_geoarrow(self, type=None, coord_type=None):
+        array_or_chunked = _ga.as_geoarrow(self._obj, type=type, coord_type=coord_type)
+        return self._wrap_series(array_or_chunked)
+
+    def bounds(self):
+        array_or_chunked = _ga.box(self._obj)
+        if isinstance(array_or_chunked, _pa.ChunkedArray):
+            flattened = [chunk.flatten() for chunk in array_or_chunked.chunks]
+            seriesish = [
+                _pa.chunked_array(item, _pa.float64()) for item in zip(*flattened)
+            ]
+        else:
+            seriesish = array_or_chunked.flatten()
+
+        return _pd.DataFrame(
+            {
+                "xmin": seriesish[0],
+                "xmax": seriesish[1],
+                "ymin": seriesish[2],
+                "ymax": seriesish[3],
+            },
+            index=self._obj.index,
+        )
+
+    def total_bounds(self):
+        struct_scalar1 = _ga.box_agg(self._obj)
+        return _pd.DataFrame({k: [v] for k, v in struct_scalar1.as_py().items()})
+
+    def with_coord_type(self, coord_type):
+        return self._wrap_series(_ga.with_coord_type(self._obj, coord_type))
+
+    def with_edge_type(self, edge_type):
+        return self._wrap_series(_ga.with_edge_type(self._obj, edge_type))
+
+    def with_crs(self, crs, crs_type=None):
+        return self._wrap_series(_ga.with_crs(self._obj, crs=crs, crs_type=crs_type))
+
+    def with_dimensions(self, dimensions):
+        return self.with_dimensions(_ga.with_coord_type(self._obj, dimensions))
+
+    def with_geometry_type(self, geometry_type):
+        return self.with_geometry_type(_ga.with_coord_type(self._obj, geometry_type))
+
+    def point_coords(self, dimensions=None):
+        return self.point_coords(_ga.with_coord_type(self._obj, dimensions))

--- a/python/geoarrow/pyarrow/__init__.py
+++ b/python/geoarrow/pyarrow/__init__.py
@@ -30,6 +30,7 @@ from ._type import (
     multilinestring,
     multipolygon,
     vector_type,
+    vector_type_common,
     register_extension_types,
     unregister_extension_types,
 )

--- a/python/geoarrow/pyarrow/_array.py
+++ b/python/geoarrow/pyarrow/_array.py
@@ -157,6 +157,7 @@ def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
     PointArray:PointType(geoarrow.point)[1]
     <POINT (0 1)>
     """
+    # Convert GeoPandas to WKB
     if type(obj).__name__ == "GeoSeries":
         if obj.crs:
             try:
@@ -167,9 +168,14 @@ def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
             type_ = wkb()
         obj = obj.to_wkb()
 
-    if type_ is None:
+    # Convert obj to array if it isn't already one
+    if isinstance(obj, pa.Array) or isinstance(obj, pa.ChunkedArray):
+        arr = obj
+    else:
         arr = pa.array(obj, *args, **kwargs)
 
+    # Handle the case where we get to pick the type
+    if type_ is None:
         if isinstance(arr.type, VectorType):
             return arr
         elif arr.type == pa.utf8():
@@ -185,11 +191,15 @@ def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
                 f"Can't create geoarrow.array from Arrow array of type {type_}"
             )
 
+    # Handle the case where the type requested is already the correct type
+    if type_ == arr.type:
+        return arr
+
     type_is_geoarrow = isinstance(type_, VectorType)
     type_is_wkb_or_wkt = type_.extension_name in ("geoarrow.wkt", "geoarrow.wkb")
 
     if type_is_geoarrow and type_is_wkb_or_wkt:
-        arr = pa.array(obj, type_.storage_type, *args, **kwargs)
+        arr = arr.cast(type_.storage_type)
         return type_.wrap_array(arr, validate=validate)
 
     # Eventually we will be able to handle more types (e.g., parse wkt or wkb

--- a/python/geoarrow/pyarrow/_array.py
+++ b/python/geoarrow/pyarrow/_array.py
@@ -170,7 +170,9 @@ def array(obj, type_=None, *args, validate=True, **kwargs) -> VectorArray:
     if type_ is None:
         arr = pa.array(obj, *args, **kwargs)
 
-        if arr.type == pa.utf8():
+        if isinstance(arr.type, VectorType):
+            return arr
+        elif arr.type == pa.utf8():
             return wkt().wrap_array(arr, validate=validate)
         elif arr.type == pa.large_utf8():
             return large_wkt().wrap_array(arr, validate=validate)

--- a/python/geoarrow/pyarrow/_type.py
+++ b/python/geoarrow/pyarrow/_type.py
@@ -84,6 +84,11 @@ class VectorType(pa.ExtensionType):
     def __arrow_ext_scalar_class__(self):
         return VectorType._scalar_cls_from_name(self.extension_name)
 
+    def to_pandas_dtype(self):
+        from .. import pandas as gapd
+
+        return gapd.GeoArrowExtensionDtype(self)
+
     def from_geobuffers(self, *args, **kwargs):
         """Create an array from the appropriate number of buffers
         for this type.

--- a/python/geoarrow/pyarrow/_type.py
+++ b/python/geoarrow/pyarrow/_type.py
@@ -60,6 +60,13 @@ class VectorType(pa.ExtensionType):
 
         return cls(c_vector_type)
 
+    @staticmethod
+    def _from_ctype(c_vector_type):
+        cls = type_cls_from_name(c_vector_type.extension_name)
+        schema = c_vector_type.to_schema()
+        storage_type = pa.DataType._import_from_c(schema._addr())
+        return cls.__arrow_ext_deserialize__(storage_type, c_vector_type.extension_metadata)
+
     def wrap_array(self, obj, validate=False):
         out = super().wrap_array(obj)
         if validate:

--- a/python/geoarrow/pyarrow/_type.py
+++ b/python/geoarrow/pyarrow/_type.py
@@ -187,6 +187,19 @@ class VectorType(pa.ExtensionType):
         """
         return self._type.crs.decode("UTF-8")
 
+    def with_metadata(self, metadata):
+        """This type with the extension metadata (e.g., copied from some other type)
+
+        >>> import geoarrow.pyarrow as ga
+        >>> ga.point().with_metadata('{"crs": "EPSG:1234"}').crs
+        'EPSG:1234'
+        """
+        if isinstance(metadata, str):
+            metadata = metadata.encode("UTF-8")
+        return type(self).__arrow_ext_deserialize__(self.storage_type, metadata)
+
+
+
     def with_geometry_type(self, geometry_type):
         """Returns a new type with the specified :class:`geoarrow.GeometryType`.
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pyarrow", "pytest", "pandas"]
+test = ["pyarrow", "pytest", "pandas", "numpy"]
 
 [project.urls]
 homepage = "https://arrow.apache.org"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pyarrow", "pytest", "pandas", "numpy"]
+test = ["pyarrow", "pytest", "pandas", "numpy", "geopandas"]
 
 [project.urls]
 homepage = "https://arrow.apache.org"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pyarrow", "pytest"]
+test = ["pyarrow", "pytest", "pandas"]
 
 [project.urls]
 homepage = "https://arrow.apache.org"

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -24,17 +24,25 @@ def test_dtype_constructor():
 def test_dtype_strings():
     dtype = gapd.GeoArrowExtensionDtype(ga.point())
     assert str(dtype) == "geoarrow.point"
+    dtype2 = gapd.GeoArrowExtensionDtype.construct_from_string(str(dtype))
+    assert dtype2 == dtype
 
     dtype = gapd.GeoArrowExtensionDtype(ga.point().with_crs("EPSG:1234"))
-    assert str(dtype) == 'geoarrow.point[{"crs":"EPSG:1234"}]'
+    assert str(dtype) == 'geoarrow.point{"crs":"EPSG:1234"}'
+    dtype2 = gapd.GeoArrowExtensionDtype.construct_from_string(str(dtype))
+    assert dtype2 == dtype
 
     dtype = gapd.GeoArrowExtensionDtype(
         ga.point().with_coord_type(ga.CoordType.INTERLEAVED)
     )
     assert str(dtype) == "geoarrow.point[interleaved]"
+    dtype2 = gapd.GeoArrowExtensionDtype.construct_from_string(str(dtype))
+    assert dtype2 == dtype
 
     dtype = gapd.GeoArrowExtensionDtype(ga.point().with_dimensions(ga.Dimensions.XYZ))
     assert str(dtype) == "geoarrow.point[Z]"
+    dtype2 = gapd.GeoArrowExtensionDtype.construct_from_string(str(dtype))
+    assert dtype2 == dtype
 
 
 def test_scalar():

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -6,7 +6,7 @@ import geoarrow.pandas as gapd
 import geoarrow.pyarrow as ga
 
 
-def test_type_constructor():
+def test_dtype_constructor():
     from_pyarrow = gapd.GeoArrowExtensionDtype(ga.point())
     assert from_pyarrow.name == "geoarrow.point"
 
@@ -20,13 +20,22 @@ def test_type_constructor():
         gapd.GeoArrowExtensionDtype(b"1234")
 
 
-def test_type_strings():
+def test_dtype_strings():
     dtype = gapd.GeoArrowExtensionDtype(ga.point())
     assert str(dtype) == "geoarrow.point"
 
     dtype = gapd.GeoArrowExtensionDtype(ga.point().with_crs("EPSG:1234"))
     assert str(dtype) == 'geoarrow.point[{"crs":"EPSG:1234"}]'
 
+
+def test_array_init_without_type():
+    array = gapd.GeoArrowExtensionArray(["POINT (0 1)"])
+    assert array._parent == ga.array(["POINT (0 1)"])
+    assert array._dtype._parent.extension_name == "geoarrow.wkt"
+
+    array = gapd.GeoArrowExtensionArray(["POINT (0 1)"], ga.wkt())
+    assert array._parent == ga.array(["POINT (0 1)"], ga.wkt())
+    assert array._dtype._parent.extension_name == "geoarrow.wkt"
 
 def test_accessor_parse_all():
     series = pd.Series(["POINT (0 1)"])

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -97,6 +97,33 @@ def test_array_basic_methods():
     )
 
 
+def test_array_concat():
+    pa_array_wkt = ga.array(["POINT (0 1)", "POINT (1 2)", None])
+    array_wkt = gapd.GeoArrowExtensionArray(pa_array_wkt)
+    array_wkt_chunkned = gapd.GeoArrowExtensionArray(pa.chunked_array([array_wkt]))
+    pa_array_geoarrow = ga.as_geoarrow(pa_array_wkt)
+    array_geoarrow = gapd.GeoArrowExtensionArray(pa_array_geoarrow)
+
+    concatenated0 = gapd.GeoArrowExtensionArray._concat_same_type([])
+    assert concatenated0.dtype == gapd.GeoArrowExtensionDtype(ga.wkb())
+    assert len(concatenated0) == 0
+
+    concatenated1 = gapd.GeoArrowExtensionArray._concat_same_type([array_wkt])
+    assert concatenated1 is array_wkt
+
+    concatenated_same_type = gapd.GeoArrowExtensionArray._concat_same_type(
+        [array_wkt, array_wkt_chunkned]
+    )
+    assert concatenated_same_type.dtype == array_wkt.dtype
+    assert len(concatenated_same_type) == 6
+
+    concatenated_diff_type = gapd.GeoArrowExtensionArray._concat_same_type(
+        [array_wkt, array_geoarrow]
+    )
+    assert concatenated_diff_type.dtype == gapd.GeoArrowExtensionDtype(ga.wkb())
+    assert len(concatenated_diff_type) == 6
+
+
 def test_pyarrow_integration():
     pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
     series = pa_array.to_pandas()

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -40,7 +40,7 @@ def test_dtype_strings():
     assert dtype2 == dtype
 
     dtype = gapd.GeoArrowExtensionDtype(ga.point().with_dimensions(ga.Dimensions.XYZ))
-    assert str(dtype) == "geoarrow.point[Z]"
+    assert str(dtype) == "geoarrow.point[z]"
     dtype2 = gapd.GeoArrowExtensionDtype.construct_from_string(str(dtype))
     assert dtype2 == dtype
 
@@ -76,9 +76,9 @@ def test_array_init_with_type():
     array = gapd.GeoArrowExtensionArray(["POINT (0 1)"], ga.wkt())
     assert array._data == ga.array(["POINT (0 1)"], ga.wkt())
     assert array._dtype._parent.extension_name == "geoarrow.wkt"
+
+
 def test_array_basic_methods():
-
-
     pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
     array = gapd.GeoArrowExtensionArray(pa_array)
 
@@ -93,7 +93,7 @@ def test_array_basic_methods():
     assert len(array) == 3
     assert all(array[:2] == array[:2])
     assert array.dtype == gapd.GeoArrowExtensionDtype(ga.wkt())
-    assert array.nbytes() == pa_array.nbytes
+    assert array.nbytes == pa_array.nbytes
     assert isinstance(array.take(np.array([1])), gapd.GeoArrowExtensionArray)
     assert array.take(np.array([1]))[0] == gapd.GeoArrowExtensionScalar("POINT (1 2)")
     np.testing.assert_array_equal(array.isna(), np.array([False, False, True]))

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -70,6 +70,13 @@ def test_array_basic_methods():
     assert all(array[:2] == array[:2])
 
 
+def test_pyarrow_integration():
+    pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
+    series = pa_array.to_pandas()
+    assert series.dtype == gapd.GeoArrowExtensionDtype(ga.wkt())
+    assert series[0] == gapd.GeoArrowExtensionScalar("POINT (0 1)")
+
+
 def test_accessor_parse_all():
     series = pd.Series(["POINT (0 1)"])
     assert series.geoarrow.parse_all() is series

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -187,9 +187,7 @@ def test_accessor_format_wkb():
 
     # Currently handles ChunkedArray explicitly
     chunked = pa.chunked_array([ga.array(["POINT (0 1)"])])
-    ga_series = pd.Series(
-        chunked, dtype=pd.ArrowDtype(chunked.type)
-    ).geoarrow.format_wkb()
+    ga_series = chunked.to_pandas().geoarrow.format_wkb()
     assert ga_series.dtype.pyarrow_dtype == pa.binary()
 
 

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -129,6 +129,7 @@ def test_pyarrow_integration():
     series = pa_array.to_pandas()
     assert series.dtype == gapd.GeoArrowExtensionDtype(ga.wkt())
     assert series[0] == gapd.GeoArrowExtensionScalar("POINT (0 1)")
+    assert pa.array(series) is pa_array
 
     pa_chunked_array = pa.chunked_array([pa_array])
     series = pa_chunked_array.to_pandas()

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -67,3 +67,26 @@ def test_total_bounds():
     assert df.ymin[0] == 1
     assert df.xmax[0] == 0
     assert df.ymax[0] == 1
+
+
+def test_point_coords():
+    pass
+
+def test_with_coord_type():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_coord_type(ga.CoordType.INTERLEAVED)
+    assert ga_series.dtype.pyarrow_dtype.coord_type == ga.CoordType.INTERLEAVED
+
+
+def test_with_edge_type():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_edge_type(ga.EdgeType.SPHERICAL)
+    assert ga_series.dtype.pyarrow_dtype.edge_type == ga.EdgeType.SPHERICAL
+
+
+def test_with_crs():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_crs("EPSG:1234")
+    assert ga_series.dtype.pyarrow_dtype.crs == "EPSG:1234"
+
+
+def test_with_dimensions():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_dimensions(ga.Dimensions.XYZ)
+    assert ga_series.dtype.pyarrow_dtype.dimensions == ga.Dimensions.XYZ

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -215,7 +215,10 @@ def test_accessor_total_bounds():
 
 
 def test_accessor_point_coords():
-    pass
+    series = pd.Series(["POINT (0 1)", "POINT (1 2)"])
+    x, y = series.geoarrow.point_coords()
+    np.testing.assert_array_equal(np.array(x), np.array([0.0, 1.0]))
+    np.testing.assert_array_equal(np.array(y), np.array([1.0, 2.0]))
 
 
 def test_accessor_with_coord_type():

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -28,6 +28,14 @@ def test_dtype_strings():
     dtype = gapd.GeoArrowExtensionDtype(ga.point().with_crs("EPSG:1234"))
     assert str(dtype) == 'geoarrow.point[{"crs":"EPSG:1234"}]'
 
+    dtype = gapd.GeoArrowExtensionDtype(
+        ga.point().with_coord_type(ga.CoordType.INTERLEAVED)
+    )
+    assert str(dtype) == "geoarrow.point[interleaved]"
+
+    dtype = gapd.GeoArrowExtensionDtype(ga.point().with_dimensions(ga.Dimensions.XYZ))
+    assert str(dtype) == "geoarrow.point[Z]"
+
 
 def test_scalar():
     scalar_from_wkt = gapd.GeoArrowExtensionScalar("POINT (0 1)")

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -1,0 +1,13 @@
+import pandas as pd
+import pyarrow as pa
+import geoarrow.pandas
+import geoarrow.pyarrow as ga
+
+
+def test_as_geoarrow():
+    series = pd.Series(["POINT (0 1)", "POINT (2 3)"])
+    ga_series = series.geoarrow.as_geoarrow()
+    assert isinstance(ga_series, pd.Series)
+
+    arr = ga.array(ga_series)
+    assert arr == ga.as_geoarrow(["POINT (0 1)", "POINT (2 3)"])

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -94,8 +94,8 @@ def test_array_basic_methods():
     assert all(array[:2] == array[:2])
     assert array.dtype == gapd.GeoArrowExtensionDtype(ga.wkt())
     assert array.nbytes() == pa_array.nbytes
-    assert isinstance(array.take([1]), gapd.GeoArrowExtensionArray)
-    assert array.take([1])[0] == gapd.GeoArrowExtensionScalar("POINT (1 2)")
+    assert isinstance(array.take(np.array([1])), gapd.GeoArrowExtensionArray)
+    assert array.take(np.array([1]))[0] == gapd.GeoArrowExtensionScalar("POINT (1 2)")
     np.testing.assert_array_equal(array.isna(), np.array([False, False, True]))
 
     assert isinstance(array.copy(), gapd.GeoArrowExtensionArray)

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pyarrow as pa
 import geoarrow.pandas as gapd
 import geoarrow.pyarrow as ga
+import numpy as np
 
 
 def test_dtype_constructor():
@@ -66,6 +67,7 @@ def test_array_basic_methods():
     array = gapd.GeoArrowExtensionArray(pa_array)
 
     assert len(array) == 3
+    assert all(array[:2] == array[:2])
 
 
 def test_accessor_parse_all():

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -1,13 +1,69 @@
+import pytest
+
 import pandas as pd
 import pyarrow as pa
 import geoarrow.pandas
 import geoarrow.pyarrow as ga
 
 
-def test_as_geoarrow():
-    series = pd.Series(["POINT (0 1)", "POINT (2 3)"])
-    ga_series = series.geoarrow.as_geoarrow()
-    assert isinstance(ga_series, pd.Series)
+def test_parse_all():
+    series = pd.Series(["POINT (0 1)"])
+    assert series.geoarrow.parse_all() is series
+    with pytest.raises(ValueError):
+        pd.Series(["NOT WKT"]).geoarrow.parse_all()
 
-    arr = ga.array(ga_series)
-    assert arr == ga.as_geoarrow(["POINT (0 1)", "POINT (2 3)"])
+
+def test_as_wkt():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_wkt()
+    assert isinstance(ga_series.dtype.pyarrow_dtype, ga.WktType)
+
+
+def test_as_wkb():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_wkb()
+    assert isinstance(ga_series.dtype.pyarrow_dtype, ga.WkbType)
+
+
+def test_format_wkt():
+    with pytest.raises(TypeError):
+        pd.Series(["POINT (0 1)"]).geoarrow.format_wkt()
+
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_geoarrow().geoarrow.format_wkt()
+    assert ga_series.dtype.pyarrow_dtype == pa.utf8()
+
+
+def test_format_wkb():
+    with pytest.raises(TypeError):
+        pd.Series(["POINT (0 1)"]).geoarrow.format_wkb()
+
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_geoarrow().geoarrow.format_wkb()
+    assert ga_series.dtype.pyarrow_dtype == pa.binary()
+
+    # Currently handles ChunkedArray explicitly
+    chunked = pa.chunked_array([ga.array(["POINT (0 1)"])])
+    ga_series = pd.Series(
+        chunked, dtype=pd.ArrowDtype(chunked.type)
+    ).geoarrow.format_wkb()
+    assert ga_series.dtype.pyarrow_dtype == pa.binary()
+
+
+def test_as_geoarrow():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_geoarrow()
+    assert isinstance(ga_series.dtype.pyarrow_dtype, ga.PointType)
+
+
+def test_bounds():
+    df = pd.Series(["POINT (0 1)"]).geoarrow.bounds()
+    assert isinstance(df, pd.DataFrame)
+    assert df.xmin[0] == 0
+    assert df.ymin[0] == 1
+    assert df.xmax[0] == 0
+    assert df.ymax[0] == 1
+
+
+def test_total_bounds():
+    df = pd.Series(["POINT (0 1)"]).geoarrow.total_bounds()
+    assert isinstance(df, pd.DataFrame)
+    assert df.xmin[0] == 0
+    assert df.ymin[0] == 1
+    assert df.xmax[0] == 0
+    assert df.ymax[0] == 1

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -243,3 +243,10 @@ def test_accessor_with_crs():
 def test_accessor_with_dimensions():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_dimensions(ga.Dimensions.XYZ)
     assert ga_series.dtype.pyarrow_dtype.dimensions == ga.Dimensions.XYZ
+
+
+def test_accessor_to_geopandas():
+    series = pd.Series(["POINT (0 1)", "POINT (1 2)"])
+    geoseries = series.geoarrow.to_geopandas()
+    assert len(geoseries) == 2
+    assert geoseries[0].wkt == "POINT (0 1)"

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -76,9 +76,9 @@ def test_array_init_with_type():
     array = gapd.GeoArrowExtensionArray(["POINT (0 1)"], ga.wkt())
     assert array._data == ga.array(["POINT (0 1)"], ga.wkt())
     assert array._dtype._parent.extension_name == "geoarrow.wkt"
-
-
 def test_array_basic_methods():
+
+
     pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
     array = gapd.GeoArrowExtensionArray(pa_array)
 

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -30,12 +30,21 @@ def test_dtype_strings():
 
 def test_array_init_without_type():
     array = gapd.GeoArrowExtensionArray(["POINT (0 1)"])
-    assert array._parent == ga.array(["POINT (0 1)"])
+    assert array._data == ga.array(["POINT (0 1)"])
     assert array._dtype._parent.extension_name == "geoarrow.wkt"
 
+
+def test_array_init_with_type():
     array = gapd.GeoArrowExtensionArray(["POINT (0 1)"], ga.wkt())
-    assert array._parent == ga.array(["POINT (0 1)"], ga.wkt())
+    assert array._data == ga.array(["POINT (0 1)"], ga.wkt())
     assert array._dtype._parent.extension_name == "geoarrow.wkt"
+
+
+def test_array_basic_methods():
+    pa_array = ga.array(["POINT (0 1)", "POINT (1 2)", None])
+    array = gapd.GeoArrowExtensionArray(pa_array)
+
+    assert len(array) == 3
 
 def test_accessor_parse_all():
     series = pd.Series(["POINT (0 1)"])

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -28,6 +28,27 @@ def test_dtype_strings():
     assert str(dtype) == 'geoarrow.point[{"crs":"EPSG:1234"}]'
 
 
+def test_scalar():
+    scalar_from_wkt = gapd.GeoArrowExtensionScalar("POINT (0 1)")
+    assert scalar_from_wkt.wkt == "POINT (0 1)"
+    assert isinstance(scalar_from_wkt.wkb, bytes)
+    assert str(scalar_from_wkt) == "POINT (0 1)"
+    assert repr(scalar_from_wkt) == 'GeoArrowExtensionScalar("POINT (0 1)")'
+
+    scalar_from_wkb = gapd.GeoArrowExtensionScalar(scalar_from_wkt.wkb)
+    assert scalar_from_wkb == scalar_from_wkt
+
+    scalar_from_scalar = gapd.GeoArrowExtensionScalar(scalar_from_wkt)
+    assert scalar_from_scalar == scalar_from_wkt
+
+    array = ga.as_geoarrow(["POINT (0 1)", "POINT (1 2)"])
+    scalar_from_array0 = gapd.GeoArrowExtensionScalar(array, 0)
+    assert scalar_from_array0 == scalar_from_wkt
+
+    scalar_from_array1 = gapd.GeoArrowExtensionScalar(array, 1)
+    assert scalar_from_array1 == gapd.GeoArrowExtensionScalar("POINT (1 2)")
+
+
 def test_array_init_without_type():
     array = gapd.GeoArrowExtensionArray(["POINT (0 1)"])
     assert array._data == ga.array(["POINT (0 1)"])
@@ -45,6 +66,7 @@ def test_array_basic_methods():
     array = gapd.GeoArrowExtensionArray(pa_array)
 
     assert len(array) == 3
+
 
 def test_accessor_parse_all():
     series = pd.Series(["POINT (0 1)"])

--- a/python/tests/test_geoarrow_pandas.py
+++ b/python/tests/test_geoarrow_pandas.py
@@ -2,28 +2,50 @@ import pytest
 
 import pandas as pd
 import pyarrow as pa
-import geoarrow.pandas
+import geoarrow.pandas as gapd
 import geoarrow.pyarrow as ga
 
 
-def test_parse_all():
+def test_type_constructor():
+    from_pyarrow = gapd.GeoArrowExtensionDtype(ga.point())
+    assert from_pyarrow.name == "geoarrow.point"
+
+    from_ctype = gapd.GeoArrowExtensionDtype(ga.point()._type)
+    assert from_ctype.name == "geoarrow.point"
+
+    from_dtype = gapd.GeoArrowExtensionDtype(from_ctype)
+    assert from_dtype.name == "geoarrow.point"
+
+    with pytest.raises(TypeError):
+        gapd.GeoArrowExtensionDtype(b"1234")
+
+
+def test_type_strings():
+    dtype = gapd.GeoArrowExtensionDtype(ga.point())
+    assert str(dtype) == "geoarrow.point"
+
+    dtype = gapd.GeoArrowExtensionDtype(ga.point().with_crs("EPSG:1234"))
+    assert str(dtype) == 'geoarrow.point[{"crs":"EPSG:1234"}]'
+
+
+def test_accessor_parse_all():
     series = pd.Series(["POINT (0 1)"])
     assert series.geoarrow.parse_all() is series
     with pytest.raises(ValueError):
         pd.Series(["NOT WKT"]).geoarrow.parse_all()
 
 
-def test_as_wkt():
+def test_accessor_as_wkt():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_wkt()
     assert isinstance(ga_series.dtype.pyarrow_dtype, ga.WktType)
 
 
-def test_as_wkb():
+def test_accessor_as_wkb():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_wkb()
     assert isinstance(ga_series.dtype.pyarrow_dtype, ga.WkbType)
 
 
-def test_format_wkt():
+def test_accessor_format_wkt():
     with pytest.raises(TypeError):
         pd.Series(["POINT (0 1)"]).geoarrow.format_wkt()
 
@@ -31,7 +53,7 @@ def test_format_wkt():
     assert ga_series.dtype.pyarrow_dtype == pa.utf8()
 
 
-def test_format_wkb():
+def test_accessor_format_wkb():
     with pytest.raises(TypeError):
         pd.Series(["POINT (0 1)"]).geoarrow.format_wkb()
 
@@ -46,12 +68,12 @@ def test_format_wkb():
     assert ga_series.dtype.pyarrow_dtype == pa.binary()
 
 
-def test_as_geoarrow():
+def test_accessor_as_geoarrow():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.as_geoarrow()
     assert isinstance(ga_series.dtype.pyarrow_dtype, ga.PointType)
 
 
-def test_bounds():
+def test_accessor_bounds():
     df = pd.Series(["POINT (0 1)"]).geoarrow.bounds()
     assert isinstance(df, pd.DataFrame)
     assert df.xmin[0] == 0
@@ -60,7 +82,7 @@ def test_bounds():
     assert df.ymax[0] == 1
 
 
-def test_total_bounds():
+def test_accessor_total_bounds():
     df = pd.Series(["POINT (0 1)"]).geoarrow.total_bounds()
     assert isinstance(df, pd.DataFrame)
     assert df.xmin[0] == 0
@@ -69,24 +91,29 @@ def test_total_bounds():
     assert df.ymax[0] == 1
 
 
-def test_point_coords():
+def test_accessor_point_coords():
     pass
 
-def test_with_coord_type():
-    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_coord_type(ga.CoordType.INTERLEAVED)
+
+def test_accessor_with_coord_type():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_coord_type(
+        ga.CoordType.INTERLEAVED
+    )
     assert ga_series.dtype.pyarrow_dtype.coord_type == ga.CoordType.INTERLEAVED
 
 
-def test_with_edge_type():
-    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_edge_type(ga.EdgeType.SPHERICAL)
+def test_accessor_with_edge_type():
+    ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_edge_type(
+        ga.EdgeType.SPHERICAL
+    )
     assert ga_series.dtype.pyarrow_dtype.edge_type == ga.EdgeType.SPHERICAL
 
 
-def test_with_crs():
+def test_accessor_with_crs():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_crs("EPSG:1234")
     assert ga_series.dtype.pyarrow_dtype.crs == "EPSG:1234"
 
 
-def test_with_dimensions():
+def test_accessor_with_dimensions():
     ga_series = pd.Series(["POINT (0 1)"]).geoarrow.with_dimensions(ga.Dimensions.XYZ)
     assert ga_series.dtype.pyarrow_dtype.dimensions == ga.Dimensions.XYZ

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -1,0 +1,213 @@
+import pytest
+from pandas.tests.extension import base
+import geoarrow.pandas as gapd
+import geoarrow.pyarrow as ga
+import operator
+
+from pandas import (
+    Series,
+    options,
+)
+
+
+@pytest.fixture
+def dtype():
+    """A fixture providing the ExtensionDtype to validate."""
+    return gapd.GeoArrowExtensionDtype(ga.wkt())
+
+
+@pytest.fixture
+def data():
+    """
+    Length-100 array for this type.
+
+    * data[0] and data[1] should both be non missing
+    * data[0] and data[1] should not be equal
+    """
+    strings = [f"POINT ({i} {i + 1})" for i in range(100)]
+    return gapd.GeoArrowExtensionArray(ga.array(strings))
+
+
+@pytest.fixture
+def data_for_twos():
+    """Length-100 array in which all the elements are two."""
+    raise NotImplementedError
+
+
+@pytest.fixture
+def data_missing():
+    """Length-2 array with [NA, Valid]"""
+    return gapd.GeoArrowExtensionArray([None, "POINT (0 1)"])
+
+
+@pytest.fixture(params=["data", "data_missing"])
+def all_data(request, data, data_missing):
+    """Parametrized fixture giving 'data' and 'data_missing'"""
+    if request.param == "data":
+        return data
+    elif request.param == "data_missing":
+        return data_missing
+
+
+@pytest.fixture
+def data_repeated(data):
+    """
+    Generate many datasets.
+
+    Parameters
+    ----------
+    data : fixture implementing `data`
+
+    Returns
+    -------
+    Callable[[int], Generator]:
+        A callable that takes a `count` argument and
+        returns a generator yielding `count` datasets.
+    """
+
+    def gen(count):
+        for _ in range(count):
+            yield data
+
+    return gen
+
+
+@pytest.fixture
+def data_for_sorting():
+    """
+    Length-3 array with a known sort order.
+
+    This should be three items [B, C, A] with
+    A < B < C
+    """
+    raise NotImplementedError
+
+
+@pytest.fixture
+def data_missing_for_sorting():
+    """
+    Length-3 array with a known sort order.
+
+    This should be three items [B, NA, A] with
+    A < B and NA missing.
+    """
+    raise NotImplementedError
+
+
+@pytest.fixture
+def na_cmp():
+    """
+    Binary operator for comparing NA values.
+
+    Should return a function of two arguments that returns
+    True if both arguments are (scalar) NA for your type.
+
+    By default, uses ``operator.is_``
+    """
+    return operator.is_
+
+
+@pytest.fixture
+def na_value():
+    """The scalar missing value for this type. Default 'None'"""
+    return None
+
+
+@pytest.fixture
+def data_for_grouping():
+    """
+    Data for factorization, grouping, and unique tests.
+
+    Expected to be like [B, B, NA, NA, A, A, B, C]
+
+    Where A < B < C and NA is missing
+    """
+    raise NotImplementedError
+
+
+@pytest.fixture(params=[True, False])
+def box_in_series(request):
+    """Whether to box the data in a Series"""
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        lambda x: 1,
+        lambda x: [1] * len(x),
+        lambda x: Series([1] * len(x)),
+        lambda x: x,
+    ],
+    ids=["scalar", "list", "series", "object"],
+)
+def groupby_apply_op(request):
+    """
+    Functions to test groupby.apply().
+    """
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_frame(request):
+    """
+    Boolean fixture to support Series and Series.to_frame() comparison testing.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_series(request):
+    """
+    Boolean fixture to support arr and Series(arr) comparison testing.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def use_numpy(request):
+    """
+    Boolean fixture to support comparison testing of ExtensionDtype array
+    and numpy array.
+    """
+    return request.param
+
+
+@pytest.fixture(params=["ffill", "bfill"])
+def fillna_method(request):
+    """
+    Parametrized fixture giving method parameters 'ffill' and 'bfill' for
+    Series.fillna(method=<method>) testing.
+    """
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_array(request):
+    """
+    Boolean fixture to support ExtensionDtype _from_sequence method testing.
+    """
+    return request.param
+
+
+@pytest.fixture
+def invalid_scalar(data):
+    """
+    A scalar that *cannot* be held by this ExtensionArray.
+
+    The default should work for most subclasses, but is not guaranteed.
+
+    If the array can hold any item (i.e. object dtype), then use pytest.skip.
+    """
+    return object.__new__(object)
+
+
+@pytest.fixture
+def using_copy_on_write() -> bool:
+    """
+    Fixture to check if Copy-on-Write is enabled.
+    """
+    return options.mode.copy_on_write and options.mode.data_manager == "block"
+
+
+class TestGeoArrowDtype(base.BaseDtypeTests):
+    pass

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -230,3 +230,31 @@ class TestGeoArrowMissing(base.BaseMissingTests):
 
     def test_fillna_series(self, data_missing):
         pytest.skip()
+
+class TestGeoArrowMethods(base.BaseMethodsTests):
+
+    def test_value_counts(self, all_data, dropna):
+        pytest.skip()
+
+    def test_value_counts_with_normalize(self, data):
+        pytest.skip()
+
+    def test_factorize_empty(self, data):
+        pytest.skip()
+
+    def test_fillna_copy_frame(self, data_missing):
+        pytest.skip()
+
+    def test_fillna_copy_series(self, data_missing):
+        pytest.skip()
+
+    def test_combine_first(self, data):
+        pytest.skip()
+
+    def test_shift_0_periods(self, data):
+        pytest.skip()
+
+    def test_where_series(self, data, na_value, as_frame):
+        pytest.skip()
+
+

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -233,7 +233,7 @@ class TestGeoArrowMissing(base.BaseMissingTests):
 
 
 class TestGeoArrowMethods(base.BaseMethodsTests):
-    def test_value_counts(self, all_data, dropna):
+    def test_value_counts(self, all_data):
         pytest.skip()
 
     def test_value_counts_with_normalize(self, data):

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -31,7 +31,7 @@ def data():
 @pytest.fixture
 def data_for_twos():
     """Length-100 array in which all the elements are two."""
-    raise NotImplementedError
+    pytest.skip()
 
 
 @pytest.fixture
@@ -80,7 +80,7 @@ def data_for_sorting():
     This should be three items [B, C, A] with
     A < B < C
     """
-    raise NotImplementedError
+    pytest.skip()
 
 
 @pytest.fixture
@@ -91,7 +91,7 @@ def data_missing_for_sorting():
     This should be three items [B, NA, A] with
     A < B and NA missing.
     """
-    raise NotImplementedError
+    pytest.skip()
 
 
 @pytest.fixture
@@ -122,7 +122,7 @@ def data_for_grouping():
 
     Where A < B < C and NA is missing
     """
-    raise NotImplementedError
+    pytest.skip()
 
 
 @pytest.fixture(params=[True, False])

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -211,3 +211,7 @@ def using_copy_on_write() -> bool:
 
 class TestGeoArrowDtype(base.BaseDtypeTests):
     pass
+
+
+class TestGeoArrowConstructors(base.BaseConstructorsTests):
+    pass

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -231,8 +231,8 @@ class TestGeoArrowMissing(base.BaseMissingTests):
     def test_fillna_series(self, data_missing):
         pytest.skip()
 
-class TestGeoArrowMethods(base.BaseMethodsTests):
 
+class TestGeoArrowMethods(base.BaseMethodsTests):
     def test_value_counts(self, all_data, dropna):
         pytest.skip()
 
@@ -258,3 +258,13 @@ class TestGeoArrowMethods(base.BaseMethodsTests):
         pytest.skip()
 
 
+class TestGeoArrowIndex(base.BaseIndexTests):
+    pass
+
+class TestGeoArrowInterface(base.BaseInterfaceTests):
+
+    def test_copy(self, data):
+        pytest.skip()
+
+    def test_view(self, data):
+        pytest.skip()

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -272,3 +272,7 @@ class TestGeoArrowInterface(base.BaseInterfaceTests):
 
 class TestGeoArrowParsing(base.BaseParsingTests):
     pass
+
+
+class TestGeoArrowPrinting(base.BasePrintingTests):
+    pass

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -261,10 +261,14 @@ class TestGeoArrowMethods(base.BaseMethodsTests):
 class TestGeoArrowIndex(base.BaseIndexTests):
     pass
 
-class TestGeoArrowInterface(base.BaseInterfaceTests):
 
+class TestGeoArrowInterface(base.BaseInterfaceTests):
     def test_copy(self, data):
         pytest.skip()
 
     def test_view(self, data):
         pytest.skip()
+
+
+class TestGeoArrowParsing(base.BaseParsingTests):
+    pass

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -219,3 +219,14 @@ class TestGeoArrowConstructors(base.BaseConstructorsTests):
 
 class TestGeoArrowGetItem(base.BaseGetitemTests):
     pass
+
+
+class TestGeoArrowMissing(base.BaseMissingTests):
+    def test_fillna_scalar(self, data_missing):
+        pytest.skip()
+
+    def test_fillna_frame(self, data_missing):
+        pytest.skip()
+
+    def test_fillna_series(self, data_missing):
+        pytest.skip()

--- a/python/tests/test_geoarrow_pandas_suite.py
+++ b/python/tests/test_geoarrow_pandas_suite.py
@@ -215,3 +215,7 @@ class TestGeoArrowDtype(base.BaseDtypeTests):
 
 class TestGeoArrowConstructors(base.BaseConstructorsTests):
     pass
+
+
+class TestGeoArrowGetItem(base.BaseGetitemTests):
+    pass

--- a/python/tests/test_geoarrow_pyarrow.py
+++ b/python/tests/test_geoarrow_pyarrow.py
@@ -82,6 +82,13 @@ def test_constructors():
     assert generic.crs_type == ga.CrsType.UNKNOWN
 
 
+def test_type_common():
+    assert ga.vector_type_common([]) == ga.wkb()
+    assert ga.vector_type_common([ga.wkt()]) == ga.wkt()
+    assert ga.vector_type_common([ga.point(), ga.point()]) == ga.point()
+    assert ga.vector_type_common([ga.point(), ga.linestring()]) == ga.wkb()
+
+
 def test_register_extension_types():
     # Unregistering once is ok
     ga.unregister_extension_types(lazy=False)


### PR DESCRIPTION
Adds:

- A `geoarrow` Series accessor (e.g., `df.geometry.geoarrow.with_crs("EPSG:4386")`). This will work for any Series that is string (interpreted as WKT) bytes (interpreted as WKB) or "geoarrow".
- A sparsely implemented "geoarrow" dtype/ExtensionArray. Currently backed by a `pyarrow.Array` or `pyarrow.ChunkedArray` but could in theory be backed by a C ArrowArray.

And, critically,

- The missing pieces required for that implementation

```python
import geoarrow.pandas
import pandas as pd

df = pd.read_parquet(
    "https://github.com/geoarrow/geoarrow-data/releases/download/latest-dev/ns-water-basin_line-wkb.parquet"
)

df.geometry[0]
#> GeoArrowExtensionScalar("LINESTRING (648686.2 50...")
```