### PR TITLE
Unpin pyarrow

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,7 +25,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-test = ["pyarrow<13.0.0", "pytest", "pandas", "numpy", "geopandas"]
+test = ["pyarrow", "pytest", "pandas", "numpy", "geopandas"]
 
 [project.urls]
 homepage = "https://arrow.apache.org"


### PR DESCRIPTION
@jorisvandenbossche any idea what's going on here? With `pyarrow<13.0.0` I get:

```python
import geoarrow.pyarrow as ga

array = ga.array(["POINT (0 1)"])
array.to_pandas().dtype
#> GeoArrowExtensionDtype(geoarrow.wkt)
```

With `pyarrow==13.0.0` I get:

```python
import geoarrow.pyarrow as ga

array = ga.array(["POINT (0 1)"])
array.to_pandas().dtype
#> dtype('O')
```