### PR TITLE
feat: Add `GEOARROW_RETURN_NOT_OK()` macro helper

### DIFF
--- a/src/geoarrow/geoarrow_type.h
+++ b/src/geoarrow/geoarrow_type.h
@@ -102,6 +102,20 @@ struct ArrowArrayStream {
 /// \ingroup geoarrow-utility
 #define GEOARROW_OK 0
 
+#define _GEOARROW_CONCAT(x, y) x##y
+#define _GEOARROW_MAKE_NAME(x, y) _GEOARROW_CONCAT(x, y)
+
+#define _GEOARROW_RETURN_NOT_OK_IMPL(NAME, EXPR) \
+  do {                                           \
+    const int NAME = (EXPR);                     \
+    if (NAME) return NAME;                       \
+  } while (0)
+
+/// \brief Macro helper for error handling
+/// \ingroup geoarrow-utility
+#define GEOARROW_RETURN_NOT_OK(EXPR) \
+  _GEOARROW_RETURN_NOT_OK_IMPL(_GEOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR)
+
 /// \brief Represents an errno-compatible error code
 /// \ingroup geoarrow-utility
 typedef int GeoArrowErrorCode;


### PR DESCRIPTION
This is pretty essential for doing any kind of readable thing with the C library. It's a little too tempting for users of `geoarrow.h` to reach into the (supposedly private) bundled nanoarrow for its helper...this should really be provided given the recommend error handling approach!