### PR TITLE
fix: Crash when metadata contains value with type that is not a list, object, or string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ out/
 CMakeUserPresets.json
 .vscode
 .Rproj.user
+.cache

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -109,6 +109,24 @@ static int SkipUntil(struct ArrowStringView* s, const char* items) {
   return 0;
 }
 
+static GeoArrowErrorCode FindNull(struct ArrowStringView* s,
+                                  struct ArrowStringView* out) {
+
+  if (s->size_bytes < 4) {
+    return EINVAL;
+  }
+
+  if (strncmp(s->data, "null", 4) != 0) {
+    return EINVAL;
+  }
+
+  out->data = s->data;
+  out->size_bytes = 4;
+  s->size_bytes -= 4;
+  s->data += 4;
+  return GEOARROW_OK;
+}
+
 static GeoArrowErrorCode FindString(struct ArrowStringView* s,
                                     struct ArrowStringView* out) {
   out->data = s->data;
@@ -245,8 +263,12 @@ static GeoArrowErrorCode ParseJSONMetadata(struct GeoArrowMetadataView* metadata
       case '\"':
         NANOARROW_RETURN_NOT_OK(FindString(s, &v));
         break;
-      default:
+      case 'n':
+        NANOARROW_RETURN_NOT_OK(FindNull(s, &v));
         break;
+      default:
+        // e.g., a number or boolean
+        return EINVAL;
     }
 
     if (k.size_bytes == 7 && strncmp(k.data, "\"edges\"", 7) == 0) {
@@ -256,14 +278,17 @@ static GeoArrowErrorCode ParseJSONMetadata(struct GeoArrowMetadataView* metadata
     } else if (k.size_bytes == 5 && strncmp(k.data, "\"crs\"", 5) == 0) {
       if (v.data[0] == '{') {
         metadata_view->crs_type = GEOARROW_CRS_TYPE_PROJJSON;
+        metadata_view->crs.data = v.data;
+        metadata_view->crs.size_bytes = v.size_bytes;
       } else if (v.data[0] == '\"') {
         metadata_view->crs_type = GEOARROW_CRS_TYPE_UNKNOWN;
+        metadata_view->crs.data = v.data;
+        metadata_view->crs.size_bytes = v.size_bytes;
+      } else if (v.data[0] == 'n') {
+        metadata_view->crs_type = GEOARROW_CRS_TYPE_NONE;
       } else {
         return EINVAL;
       }
-
-      metadata_view->crs.data = v.data;
-      metadata_view->crs.size_bytes = v.size_bytes;
     }
 
     SkipUntil(s, ",}");

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -2,7 +2,6 @@
 #include <errno.h>
 #include <stdio.h>
 
-#include "geoarrow_type.h"
 #include "nanoarrow.h"
 
 #include "geoarrow.h"
@@ -112,7 +111,6 @@ static int SkipUntil(struct ArrowStringView* s, const char* items) {
 
 static GeoArrowErrorCode FindNull(struct ArrowStringView* s,
                                   struct ArrowStringView* out) {
-
   if (s->size_bytes < 4) {
     return EINVAL;
   }

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -2,6 +2,7 @@
 #include <errno.h>
 #include <stdio.h>
 
+#include "geoarrow_type.h"
 #include "nanoarrow.h"
 
 #include "geoarrow.h"
@@ -274,6 +275,12 @@ static GeoArrowErrorCode ParseJSONMetadata(struct GeoArrowMetadataView* metadata
     if (k.size_bytes == 7 && strncmp(k.data, "\"edges\"", 7) == 0) {
       if (v.size_bytes == 11 && strncmp(v.data, "\"spherical\"", 11) == 0) {
         metadata_view->edge_type = GEOARROW_EDGE_TYPE_SPHERICAL;
+      } else if (v.size_bytes == 8 && strncmp(v.data, "\"planar\"", 8) == 0) {
+        metadata_view->edge_type = GEOARROW_EDGE_TYPE_PLANAR;
+      } else if (v.data[0] == 'n') {
+        metadata_view->edge_type = GEOARROW_EDGE_TYPE_PLANAR;
+      } else {
+        return EINVAL;
       }
     } else if (k.size_bytes == 5 && strncmp(k.data, "\"crs\"", 5) == 0) {
       if (v.data[0] == '{') {

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -132,6 +132,34 @@ TEST(MetadataTest, MetadataTestReadJSON) {
   EXPECT_EQ(metadata_view.edge_type, GEOARROW_EDGE_TYPE_PLANAR);
   EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_NONE);
   EXPECT_EQ(metadata_view.crs.size_bytes, 0);
+
+  const char* json_edges_none = "{\"edges\":null}";
+  metadata.data = json_edges_none;
+  metadata.size_bytes = strlen(json_edges_none);
+
+  EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), GEOARROW_OK);
+  EXPECT_EQ(metadata_view.edge_type, GEOARROW_EDGE_TYPE_PLANAR);
+  EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_NONE);
+  EXPECT_EQ(metadata_view.crs.size_bytes, 0);
+
+  const char* json_edges_planar = "{\"edges\":\"planar\"}";
+  metadata.data = json_edges_planar;
+  metadata.size_bytes = strlen(json_edges_planar);
+
+  EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), GEOARROW_OK);
+  EXPECT_EQ(metadata_view.edge_type, GEOARROW_EDGE_TYPE_PLANAR);
+  EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_NONE);
+  EXPECT_EQ(metadata_view.crs.size_bytes, 0);
+
+  const char* json_edges_invalid = "{\"edges\":\"unsupported value\"}";
+  metadata.data = json_edges_invalid;
+  metadata.size_bytes = strlen(json_edges_invalid);
+  EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), EINVAL);
+
+  const char* json_edges_invalid_type = "{\"edges\":true}";
+  metadata.data = json_edges_invalid_type;
+  metadata.size_bytes = strlen(json_edges_invalid_type);
+  EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), EINVAL);
 }
 
 TEST(MetadataTest, MetadataTestSetMetadata) {

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include <geoarrow.h>
-#include <sys/errno.h>
 #include "nanoarrow.h"
 
 TEST(MetadataTest, MetadataTestEmpty) {

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -123,6 +123,15 @@ TEST(MetadataTest, MetadataTestReadJSON) {
   EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_UNKNOWN);
   EXPECT_EQ(std::string(metadata_view.crs.data, metadata_view.crs.size_bytes),
             "\"a string\"");
+
+  const char* json_crs_none = "{\"crs\":null}";
+  metadata.data = json_crs_none;
+  metadata.size_bytes = strlen(json_crs_none);
+
+  EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), GEOARROW_OK);
+  EXPECT_EQ(metadata_view.edge_type, GEOARROW_EDGE_TYPE_PLANAR);
+  EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_NONE);
+  EXPECT_EQ(metadata_view.crs.size_bytes, 0);
 }
 
 TEST(MetadataTest, MetadataTestSetMetadata) {


### PR DESCRIPTION
Uncovered by https://github.com/geoarrow/geoarrow-r/issues/34 !

Basically, because we did a `break` instead of `return EINVAL`, we exposed uninitialized memory which (sometimes) caused a crash.

I also added the ability to treat edges/crs as `null` as identical to missing (even though it's technically not valid).