### PR TITLE
chore: Always export extension metadata

### DIFF
--- a/src/geoarrow/geoarrow_arrow.hpp
+++ b/src/geoarrow/geoarrow_arrow.hpp
@@ -90,8 +90,6 @@ class VectorExtensionType : public arrow::ExtensionType {
 
   std::string Serialize() const override { return type_.extension_metadata(); }
 
-  std::string ToString() const override { return arrow::ExtensionType::ToString(); }
-
   const VectorType& GeoArrowType() const { return type_; }
 
   arrow::Result<std::shared_ptr<VectorExtensionType>> WithGeometryType(

--- a/src/geoarrow/schema.c
+++ b/src/geoarrow/schema.c
@@ -156,6 +156,13 @@ GeoArrowErrorCode GeoArrowSchemaInitExtension(struct ArrowSchema* schema,
     return result;
   }
 
+  result = ArrowMetadataBuilderAppend(
+      &metadata, ArrowCharView("ARROW:extension:metadata"), ArrowCharView("{}"));
+  if (result != NANOARROW_OK) {
+    ArrowBufferReset(&metadata);
+    return result;
+  }
+
   result = GeoArrowSchemaInit(schema, type);
   if (result != NANOARROW_OK) {
     ArrowBufferReset(&metadata);


### PR DESCRIPTION
Apparently Arrow C++ will throw an exception if you register an extension type with metadata but attempt to create an instance *without* metadata.