### PR TITLE
fix!: Generate child fields as non-nullable

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -51,6 +51,8 @@ jobs:
       - name: Coverage (geoarrow-c)
         if: success() && matrix.python-version == '3.12'
         run: |
+          pip install setuptools Cython
+
           pushd python/geoarrow-c
 
           # Build with Cython + gcc coverage options

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -19,15 +19,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          repository: geoarrow/geoarrow-python
-          path: geoarrow-python
-
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -40,27 +35,9 @@ jobs:
           pushd python/geoarrow-c
           pip install ".[test]"
 
-      - name: Install (geoarrow-pyarrow)
-        run: |
-          pushd geoarrow-python/geoarrow-pyarrow
-          pip install ".[test]"
-
-      - name: Install (geoarrow-pandas)
-        run: |
-          pushd geoarrow-python/geoarrow-pandas
-          pip install ".[test]"
-
       - name: Run tests (geoarrow-c)
         run: |
           pytest python/geoarrow-c/tests -v -s
-
-      - name: Run tests (geoarrow-pyarrow)
-        run: |
-          pytest geoarrow-python/geoarrow-pyarrow/tests -v -s
-
-      - name: Run tests (geoarrow-pandas)
-        run: |
-          pytest geoarrow-python/geoarrow-pandas/tests -v -s
 
       - name: Install coverage dependencies
         run: |
@@ -72,7 +49,7 @@ jobs:
           pip install -e python/geoarrow-c/
 
       - name: Coverage (geoarrow-c)
-        if: success() && matrix.python-version == '3.11'
+        if: success() && matrix.python-version == '3.12'
         run: |
           pushd python/geoarrow-c
 
@@ -99,13 +76,13 @@ jobs:
           popd
 
       - name: Upload coverage to codecov
-        if: success() && matrix.python-version == '3.11'
+        if: success() && matrix.python-version == '3.12'
         uses: codecov/codecov-action@v2
         with:
           files: 'python/geoarrow-c/coverage.info,python/geoarrow-c/coverage.xml'
 
       - name: Run doctests
-        if: success() && matrix.python-version == '3.11'
+        if: success() && matrix.python-version == '3.12'
         run: |
           pushd python/geoarrow-c
           pytest --pyargs geoarrow.c --doctest-modules

--- a/python/geoarrow-c/tests/test_geoarrow_lib.py
+++ b/python/geoarrow-c/tests/test_geoarrow_lib.py
@@ -98,7 +98,10 @@ def test_c_vector_type():
 
     pa_type = pa.DataType._import_from_c(schema._addr())
     pa_type_expected = pa.struct(
-        [pa.field("x", pa.float64()), pa.field("y", pa.float64())]
+        [
+            pa.field("x", pa.float64(), nullable=False),
+            pa.field("y", pa.float64(), nullable=False),
+        ]
     )
 
     # Depending on how the tests are run, the extension type might be

--- a/src/geoarrow/schema.c
+++ b/src/geoarrow/schema.c
@@ -15,8 +15,7 @@ static GeoArrowErrorCode GeoArrowSchemaInitCoordFixedSizeList(struct ArrowSchema
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema->children[0], dims));
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_DOUBLE));
 
-  // Set this type and its child non-nullable
-  schema->flags = 0;
+  // Set child field non-nullable
   schema->children[0]->flags = 0;
 
   return GEOARROW_OK;
@@ -36,9 +35,6 @@ static GeoArrowErrorCode GeoArrowSchemaInitCoordStruct(struct ArrowSchema* schem
     // Set child non-nullable
     schema->children[i]->flags = 0;
   }
-
-  // Set this type non-nullable
-  schema->flags = 0;
 
   return GEOARROW_OK;
 }
@@ -63,6 +59,10 @@ static GeoArrowErrorCode GeoArrowSchemaInitListOf(struct ArrowSchema* schema,
     NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitListOf(schema->children[0], coord_type,
                                                      dims, n - 1, child_names + 1));
     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema->children[0], child_names[0]));
+
+    // Set child field non-nullable
+    schema->children[0]->flags = 0;
+
     return NANOARROW_OK;
   }
 }
@@ -130,6 +130,7 @@ GeoArrowErrorCode GeoArrowSchemaInit(struct ArrowSchema* schema, enum GeoArrowTy
         default:
           return EINVAL;
       }
+      break;
 
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
       NANOARROW_RETURN_NOT_OK(
@@ -155,9 +156,6 @@ GeoArrowErrorCode GeoArrowSchemaInit(struct ArrowSchema* schema, enum GeoArrowTy
     default:
       return ENOTSUP;
   }
-
-  // Outer schema is always nullable
-  schema->flags = ARROW_FLAG_NULLABLE;
 
   return NANOARROW_OK;
 }

--- a/src/geoarrow/schema.c
+++ b/src/geoarrow/schema.c
@@ -15,6 +15,10 @@ static GeoArrowErrorCode GeoArrowSchemaInitCoordFixedSizeList(struct ArrowSchema
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema->children[0], dims));
   NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_DOUBLE));
 
+  // Set this type and its child non-nullable
+  schema->flags = 0;
+  schema->children[0]->flags = 0;
+
   return GEOARROW_OK;
 }
 
@@ -29,15 +33,20 @@ static GeoArrowErrorCode GeoArrowSchemaInitCoordStruct(struct ArrowSchema* schem
     NANOARROW_RETURN_NOT_OK(
         ArrowSchemaInitFromType(schema->children[i], NANOARROW_TYPE_DOUBLE));
     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema->children[i], dim_name));
+    // Set child non-nullable
+    schema->children[i]->flags = 0;
   }
+
+  // Set this type non-nullable
+  schema->flags = 0;
 
   return GEOARROW_OK;
 }
 
-static GeoArrowErrorCode GeoArrowSchemaInitListStruct(struct ArrowSchema* schema,
-                                                      enum GeoArrowCoordType coord_type,
-                                                      const char* dims, int n,
-                                                      const char** child_names) {
+static GeoArrowErrorCode GeoArrowSchemaInitListOf(struct ArrowSchema* schema,
+                                                  enum GeoArrowCoordType coord_type,
+                                                  const char* dims, int n,
+                                                  const char** child_names) {
   if (n == 0) {
     switch (coord_type) {
       case GEOARROW_COORD_TYPE_SEPARATE:
@@ -51,9 +60,10 @@ static GeoArrowErrorCode GeoArrowSchemaInitListStruct(struct ArrowSchema* schema
     ArrowSchemaInit(schema);
     NANOARROW_RETURN_NOT_OK(ArrowSchemaSetFormat(schema, "+l"));
     NANOARROW_RETURN_NOT_OK(ArrowSchemaAllocateChildren(schema, 1));
-    NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitListStruct(schema->children[0], coord_type,
-                                                         dims, n - 1, child_names + 1));
-    return ArrowSchemaSetName(schema->children[0], child_names[0]);
+    NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitListOf(schema->children[0], coord_type,
+                                                     dims, n - 1, child_names + 1));
+    NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema->children[0], child_names[0]));
+    return NANOARROW_OK;
   }
 }
 
@@ -112,32 +122,44 @@ GeoArrowErrorCode GeoArrowSchemaInit(struct ArrowSchema* schema, enum GeoArrowTy
     case GEOARROW_GEOMETRY_TYPE_POINT:
       switch (coord_type) {
         case GEOARROW_COORD_TYPE_SEPARATE:
-          return GeoArrowSchemaInitCoordStruct(schema, dims);
+          NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitCoordStruct(schema, dims));
+          break;
         case GEOARROW_COORD_TYPE_INTERLEAVED:
-          return GeoArrowSchemaInitCoordFixedSizeList(schema, dims);
+          NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitCoordFixedSizeList(schema, dims));
+          break;
         default:
           return EINVAL;
       }
 
     case GEOARROW_GEOMETRY_TYPE_LINESTRING:
-      return GeoArrowSchemaInitListStruct(schema, coord_type, dims, 1,
-                                          CHILD_NAMES_LINESTRING);
+      NANOARROW_RETURN_NOT_OK(
+          GeoArrowSchemaInitListOf(schema, coord_type, dims, 1, CHILD_NAMES_LINESTRING));
+      break;
     case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:
-      return GeoArrowSchemaInitListStruct(schema, coord_type, dims, 1,
-                                          CHILD_NAMES_MULTIPOINT);
+      NANOARROW_RETURN_NOT_OK(
+          GeoArrowSchemaInitListOf(schema, coord_type, dims, 1, CHILD_NAMES_MULTIPOINT));
+      break;
     case GEOARROW_GEOMETRY_TYPE_POLYGON:
-      return GeoArrowSchemaInitListStruct(schema, coord_type, dims, 2,
-                                          CHILD_NAMES_POLYGON);
+      NANOARROW_RETURN_NOT_OK(
+          GeoArrowSchemaInitListOf(schema, coord_type, dims, 2, CHILD_NAMES_POLYGON));
+      break;
     case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:
-      return GeoArrowSchemaInitListStruct(schema, coord_type, dims, 2,
-                                          CHILD_NAMES_MULTILINESTRING);
+      NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitListOf(schema, coord_type, dims, 2,
+                                                       CHILD_NAMES_MULTILINESTRING));
+      break;
     case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:
-      return GeoArrowSchemaInitListStruct(schema, coord_type, dims, 3,
-                                          CHILD_NAMES_MULTIPOLYGON);
+      NANOARROW_RETURN_NOT_OK(GeoArrowSchemaInitListOf(schema, coord_type, dims, 3,
+                                                       CHILD_NAMES_MULTIPOLYGON));
+      break;
 
     default:
       return ENOTSUP;
   }
+
+  // Outer schema is always nullable
+  schema->flags = ARROW_FLAG_NULLABLE;
+
+  return NANOARROW_OK;
 }
 
 GeoArrowErrorCode GeoArrowSchemaInitExtension(struct ArrowSchema* schema,


### PR DESCRIPTION
This aligns geoarrow-c with geoarrow-rs and the geoarrow implementation in the forthcoming geopandas!

This is a huge breaking change in the sense that it causes a lot of tests to fail in geoarrow-pyarrow; however, it is not much of a breaking change in the sense that the implementations here never check the nullability flag on import (and geoarrow-pyarrow defers to them almost everywhere).