### PR TITLE
fix: Fix passing NULL to memcpy when unescaping a CRS value

### DIFF
--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -552,7 +552,7 @@ int64_t GeoArrowUnescapeCrs(struct GeoArrowStringView crs, char* out, int64_t n)
     if (n > crs.size_bytes) {
       memcpy(out, crs.data, crs.size_bytes);
       out[crs.size_bytes] = '\0';
-    } else {
+    } else if (out != NULL) {
       memcpy(out, crs.data, n);
     }
 


### PR DESCRIPTION
Found by the CRAN check: https://www.stats.ox.ac.uk/pub/bdr/memtests/gcc-UBSAN/geoarrow/tests/testthat.Rout

```
geoarrow.c:4843:7: runtime error: null pointer passed as argument 1, which is declared to never be null
    #0 0x7f0fcf929ecf in GeoArrowUnescapeCrs /data/gannet/ripley/R/packages/tests-gcc-SAN/geoarrow/src/geoarrow.c:4843
    #1 0x7f0fcf9e453b in geoarrow_c_schema_parse /data/gannet/ripley/R/packages/tests-gcc-SAN/geoarrow/src/r-type.c:82
    #2 0x58c2e5 in R_doDotCall /data/gannet/ripley/R/svn/R-devel/src/main/dotcode.c:757
    #3 0x652927 in bcEval_loop /data/gannet/ripley/R/svn/R-devel/src/main/eval.c:8690
    #4 0x68d632 in bcEval /data/gannet/ripley/R/svn/R-devel/src/main/eval.c:7523
```