### PR TITLE
feat: Support crs_type values in most recent spec release candidate

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,9 @@
         {
             "name": "default",
             "displayName": "Default Config",
-            "cacheVariables": {}
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
         },
         {
             "name": "default-with-tests",

--- a/python/geoarrow-c/src/geoarrow/c/_lib.pyx
+++ b/python/geoarrow-c/src/geoarrow/c/_lib.pyx
@@ -125,6 +125,9 @@ cdef extern from "geoarrow_type.h":
         GEOARROW_CRS_TYPE_NONE
         GEOARROW_CRS_TYPE_UNKNOWN
         GEOARROW_CRS_TYPE_PROJJSON
+        GEOARROW_CRS_TYPE_WKT2_2019
+        GEOARROW_CRS_TYPE_AUTHORITY_CODE
+        GEOARROW_CRS_TYPE_SRID
 
     struct GeoArrowError:
         char message[1024]

--- a/python/geoarrow-c/src/geoarrow/c/lib.py
+++ b/python/geoarrow-c/src/geoarrow/c/lib.py
@@ -119,3 +119,9 @@ class CrsType:
     UNKNOWN = _lib.GEOARROW_CRS_TYPE_UNKNOWN
     #: The CRS value is a PROJJSON-encoded string
     PROJJSON = _lib.GEOARROW_CRS_TYPE_PROJJSON
+    #: The CRS value is a WKT:2019-encoded string
+    WKT2_2019 = _lib.GEOARROW_CRS_TYPE_WKT2_2019
+    #: The CRS value is a authority:code-encoded string
+    AUTHORITY_CODE = _lib.GEOARROW_CRS_TYPE_AUTHORITY_CODE
+    #: The CRS value is an opaque producer-defined identifier
+    SRID = _lib.GEOARROW_CRS_TYPE_SRID

--- a/src/geoarrow/geoarrow.h
+++ b/src/geoarrow/geoarrow.h
@@ -105,6 +105,10 @@ GeoArrowErrorCode GeoArrowSchemaSetMetadata(
 GeoArrowErrorCode GeoArrowSchemaSetMetadataFrom(struct ArrowSchema* schema,
                                                 const struct ArrowSchema* schema_src);
 
+/// \brief Set a GeoArrowMetadatView with the Crs definition of OGC:CRS84,
+/// the most commonly used CRS definition for longitude/latitude.
+void GeoArrowMetadataSetLonLat(struct GeoArrowMetadataView* metadata_view);
+
 /// \brief Unescape a coordinate reference system value
 ///
 /// The crs member of the GeoArrowMetadataView is a view into the extension metadata;

--- a/src/geoarrow/geoarrow.h
+++ b/src/geoarrow/geoarrow.h
@@ -112,7 +112,7 @@ void GeoArrowMetadataSetLonLat(struct GeoArrowMetadataView* metadata_view);
 /// \brief Unescape a coordinate reference system value
 ///
 /// The crs member of the GeoArrowMetadataView is a view into the extension metadata;
-/// however, in some cases this will be a quoted string (i.e., `"EPSG:4326"`) and in
+/// however, in some cases this will be a quoted string (i.e., `"OGC:CRS84"`) and in
 /// others it will be a JSON object (i.e., PROJJSON like
 /// `{"some key": "some value", ..}`). When passing this string elsewhere, you will
 /// almost always want the quoted value to be unescaped (i.e., the JSON string value),

--- a/src/geoarrow/geoarrow.h
+++ b/src/geoarrow/geoarrow.h
@@ -100,11 +100,6 @@ int64_t GeoArrowMetadataSerialize(const struct GeoArrowMetadataView* metadata_vi
 GeoArrowErrorCode GeoArrowSchemaSetMetadata(
     struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view);
 
-/// \brief Deprecated function used for backward compatibility with very early
-/// versions of geoarrow
-GeoArrowErrorCode GeoArrowSchemaSetMetadataDeprecated(
-    struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view);
-
 /// \brief Update extension metadata associated with an existing ArrowSchema
 /// based on the extension metadata of another
 GeoArrowErrorCode GeoArrowSchemaSetMetadataFrom(struct ArrowSchema* schema,

--- a/src/geoarrow/geoarrow_type.h
+++ b/src/geoarrow/geoarrow_type.h
@@ -2,7 +2,6 @@
 #ifndef GEOARROW_GEOARROW_TYPES_H_INCLUDED
 #define GEOARROW_GEOARROW_TYPES_H_INCLUDED
 
-#include <stddef.h>
 #include <stdint.h>
 
 #include "geoarrow_config.h"
@@ -270,7 +269,10 @@ enum GeoArrowEdgeType { GEOARROW_EDGE_TYPE_PLANAR, GEOARROW_EDGE_TYPE_SPHERICAL 
 enum GeoArrowCrsType {
   GEOARROW_CRS_TYPE_NONE,
   GEOARROW_CRS_TYPE_UNKNOWN,
-  GEOARROW_CRS_TYPE_PROJJSON
+  GEOARROW_CRS_TYPE_PROJJSON,
+  GEOARROW_CRS_TYPE_WKT2_2019,
+  GEOARROW_CRS_TYPE_AUTHORITY_CODE,
+  GEOARROW_CRS_TYPE_SRID
 };
 
 /// \brief Parsed view of an ArrowSchema representation of a GeoArrowType

--- a/src/geoarrow/geoarrow_type_inline.h
+++ b/src/geoarrow/geoarrow_type_inline.h
@@ -78,6 +78,40 @@ static inline const char* GeoArrowExtensionNameFromType(enum GeoArrowType type) 
   }
 }
 
+/// \brief Returns a string representation of a GeoArrowEdgeType
+/// \ingroup geoarrow-schema
+static inline const char* GeoArrowEdgeTypeString(enum GeoArrowEdgeType edge_type) {
+  switch (edge_type) {
+    case GEOARROW_EDGE_TYPE_PLANAR:
+      return "planar";
+    case GEOARROW_EDGE_TYPE_SPHERICAL:
+      return "spherical";
+    default:
+      return "";
+  }
+}
+
+/// \brief Returns a string representation of a GeoArrowCrsType
+/// \ingroup geoarrow-schema
+static inline const char* GeoArrowCrsTypeString(enum GeoArrowCrsType crs_type) {
+  switch (crs_type) {
+    case GEOARROW_CRS_TYPE_NONE:
+      return "none";
+    case GEOARROW_CRS_TYPE_UNKNOWN:
+      return "unknown";
+    case GEOARROW_CRS_TYPE_PROJJSON:
+      return "projjson";
+    case GEOARROW_CRS_TYPE_WKT2_2019:
+      return "wkt2:2019";
+    case GEOARROW_CRS_TYPE_AUTHORITY_CODE:
+      return "authority_code";
+    case GEOARROW_CRS_TYPE_SRID:
+      return "srid";
+    default:
+      return "";
+  }
+}
+
 /// \brief Extract GeoArrowDimensions from a GeoArrowType
 /// \ingroup geoarrow-schema
 static inline enum GeoArrowDimensions GeoArrowDimensionsFromType(enum GeoArrowType type) {

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -331,81 +331,159 @@ GeoArrowErrorCode GeoArrowMetadataViewInit(struct GeoArrowMetadataView* metadata
   return GeoArrowMetadataViewInitJSON(metadata_view, error);
 }
 
-static GeoArrowErrorCode GeoArrowMetadataSerializeInternal(
-    const struct GeoArrowMetadataView* metadata_view, struct ArrowBuffer* buffer) {
-  NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, "{", 1));
+static int GeoArrowMetadataCrsNeedsEscape(struct GeoArrowStringView crs) {
+  return (crs.size_bytes == 0) || (*crs.data != '{' && *crs.data != '"');
+}
 
-  int needs_leading_comma = 0;
-  const char* spherical_edges_json = "\"edges\":\"spherical\"";
-  switch (metadata_view->edge_type) {
-    case GEOARROW_EDGE_TYPE_SPHERICAL:
-      NANOARROW_RETURN_NOT_OK(
-          ArrowBufferAppend(buffer, spherical_edges_json, strlen(spherical_edges_json)));
-      needs_leading_comma = 1;
-      break;
-    default:
-      break;
+static int64_t GeoArrowMetadataCalculateSerializedSize(
+    const struct GeoArrowMetadataView* metadata_view) {
+  const int64_t kSizeOuterBraces = 2;
+  const int64_t kSizeQuotes = 2;
+  const int64_t kSizeColon = 1;
+  const int64_t kSizeComma = 1;
+  const int64_t kSizeEdgesKey = 5 + kSizeQuotes + kSizeColon;
+  const int64_t kSizeCrsTypeKey = 8 + kSizeQuotes + kSizeColon;
+  const int64_t kSizeCrsKey = 3 + kSizeQuotes + kSizeColon;
+
+  int n_keys = 0;
+  int64_t size_out = 0;
+  size_out += kSizeOuterBraces;
+
+  if (metadata_view->edge_type != GEOARROW_EDGE_TYPE_PLANAR) {
+    n_keys += 1;
+    size_out += kSizeEdgesKey + kSizeQuotes +
+                strlen(GeoArrowEdgeTypeString(metadata_view->edge_type));
   }
 
-  if (metadata_view->crs_type != GEOARROW_CRS_TYPE_NONE && needs_leading_comma) {
-    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, ",", 1));
+  if (metadata_view->crs_type != GEOARROW_CRS_TYPE_UNKNOWN &&
+      metadata_view->crs_type != GEOARROW_CRS_TYPE_NONE) {
+    n_keys += 1;
+    size_out += kSizeCrsTypeKey + kSizeQuotes +
+                strlen(GeoArrowCrsTypeString(metadata_view->crs_type));
   }
 
   if (metadata_view->crs_type != GEOARROW_CRS_TYPE_NONE) {
-    const char* crs_json_prefix = "\"crs\":";
-    NANOARROW_RETURN_NOT_OK(
-        ArrowBufferAppend(buffer, crs_json_prefix, strlen(crs_json_prefix)));
-  }
+    n_keys += 1;
+    size_out += kSizeCrsKey;
 
-  if (metadata_view->crs_type == GEOARROW_CRS_TYPE_PROJJSON) {
-    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, metadata_view->crs.data,
-                                              metadata_view->crs.size_bytes));
-  } else if (metadata_view->crs_type == GEOARROW_CRS_TYPE_UNKNOWN) {
-    // Escape quotes in the string if the string does not start with '"'
-    if (metadata_view->crs.size_bytes > 0 && metadata_view->crs.data[0] == '\"') {
-      NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, metadata_view->crs.data,
-                                                metadata_view->crs.size_bytes));
-    } else {
-      NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, "\"", 1));
+    if (GeoArrowMetadataCrsNeedsEscape(metadata_view->crs)) {
+      size_out += kSizeQuotes + metadata_view->crs.size_bytes;
       for (int64_t i = 0; i < metadata_view->crs.size_bytes; i++) {
-        char c = metadata_view->crs.data[i];
-        if (c == '\"') {
-          NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, "\\", 1));
-        }
-        NANOARROW_RETURN_NOT_OK(ArrowBufferAppendInt8(buffer, c));
+        char val = metadata_view->crs.data[i];
+        size_out += val == '\\' || val == '"';
       }
-      NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, "\"", 1));
+    } else {
+      size_out += metadata_view->crs.size_bytes;
     }
   }
 
-  NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(buffer, "}", 1));
-  return GEOARROW_OK;
+  if (n_keys > 1) {
+    size_out += kSizeComma * (n_keys - 1);
+  }
+
+  return size_out;
+}
+
+static void GeoArrowWriteStringView(struct ArrowStringView sv, char** out) {
+  if (sv.size_bytes == 0) {
+    return;
+  }
+
+  memcpy(*out, sv.data, sv.size_bytes);
+  (*out) += sv.size_bytes;
+}
+
+static void GeoArrowWriteString(const char* value, char** out) {
+  GeoArrowWriteStringView(ArrowCharView(value), out);
+}
+
+static int64_t GeoArrowMetadataSerializeInternal(
+    const struct GeoArrowMetadataView* metadata_view, char* out) {
+  const struct ArrowStringView kEdgesKey = ArrowCharView("\"edges\":");
+  const struct ArrowStringView kCrsTypeKey = ArrowCharView("\"crs_type\":");
+  const struct ArrowStringView kCrsKey = ArrowCharView("\"crs\":");
+
+  char* out_initial = out;
+  int n_keys = 0;
+
+  *out++ = '{';
+
+  if (metadata_view->edge_type != GEOARROW_EDGE_TYPE_PLANAR) {
+    n_keys += 1;
+    GeoArrowWriteStringView(kEdgesKey, &out);
+    *out++ = '"';
+    GeoArrowWriteString(GeoArrowEdgeTypeString(metadata_view->edge_type), &out);
+    *out++ = '"';
+  }
+
+  if (metadata_view->crs_type != GEOARROW_CRS_TYPE_UNKNOWN &&
+      metadata_view->crs_type != GEOARROW_CRS_TYPE_NONE) {
+    if (n_keys > 0) {
+      *out++ = ',';
+    }
+
+    n_keys += 1;
+    GeoArrowWriteStringView(kCrsTypeKey, &out);
+    *out++ = '"';
+    GeoArrowWriteString(GeoArrowCrsTypeString(metadata_view->crs_type), &out);
+    *out++ = '"';
+  }
+
+  if (metadata_view->crs_type != GEOARROW_CRS_TYPE_NONE) {
+    if (n_keys > 0) {
+      *out++ = ',';
+    }
+
+    n_keys += 1;
+    GeoArrowWriteStringView(kCrsKey, &out);
+
+    if (GeoArrowMetadataCrsNeedsEscape(metadata_view->crs)) {
+      *out++ = '"';
+      for (int64_t i = 0; i < metadata_view->crs.size_bytes; i++) {
+        char val = metadata_view->crs.data[i];
+        if (val == '"') {
+          *out++ = '\\';
+        }
+
+        *out++ = val;
+      }
+      *out++ = '"';
+    } else {
+      struct ArrowStringView sv;
+      sv.data = metadata_view->crs.data;
+      sv.size_bytes = metadata_view->crs.size_bytes;
+      GeoArrowWriteStringView(sv, &out);
+    }
+  }
+
+  *out++ = '}';
+  return out - out_initial;
 }
 
 static GeoArrowErrorCode GeoArrowSchemaSetMetadataInternal(
     struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view) {
-  struct ArrowBuffer buffer;
-  ArrowBufferInit(&buffer);
-
-  int result = GeoArrowMetadataSerializeInternal(metadata_view, &buffer);
-  if (result != GEOARROW_OK) {
-    ArrowBufferReset(&buffer);
-    return result;
+  int64_t metadata_size = GeoArrowMetadataCalculateSerializedSize(metadata_view);
+  char* metadata = (char*)ArrowMalloc(metadata_size);
+  if (metadata == NULL) {
+    return ENOMEM;
   }
 
+  int64_t chars_written = GeoArrowMetadataSerializeInternal(metadata_view, metadata);
+  NANOARROW_DCHECK(chars_written == metadata_size);
+
   struct ArrowBuffer existing_buffer;
-  result = ArrowMetadataBuilderInit(&existing_buffer, schema->metadata);
+  int result = ArrowMetadataBuilderInit(&existing_buffer, schema->metadata);
   if (result != GEOARROW_OK) {
-    ArrowBufferReset(&buffer);
+    ArrowFree(metadata);
     return result;
   }
 
   struct ArrowStringView value;
-  value.data = (const char*)buffer.data;
-  value.size_bytes = buffer.size_bytes;
+  value.data = metadata;
+  value.size_bytes = metadata_size;
   result = ArrowMetadataBuilderSet(&existing_buffer,
                                    ArrowCharView("ARROW:extension:metadata"), value);
-  ArrowBufferReset(&buffer);
+  ArrowFree(metadata);
   if (result != GEOARROW_OK) {
     ArrowBufferReset(&existing_buffer);
     return result;
@@ -418,38 +496,18 @@ static GeoArrowErrorCode GeoArrowSchemaSetMetadataInternal(
 
 int64_t GeoArrowMetadataSerialize(const struct GeoArrowMetadataView* metadata_view,
                                   char* out, int64_t n) {
-  struct ArrowBuffer buffer;
-  ArrowBufferInit(&buffer);
-  int result = ArrowBufferReserve(&buffer, n);
-  if (result != GEOARROW_OK) {
-    ArrowBufferReset(&buffer);
-    return -1;
+  int64_t metadata_size = GeoArrowMetadataCalculateSerializedSize(metadata_view);
+  if (metadata_size <= n) {
+    int64_t chars_written = GeoArrowMetadataSerializeInternal(metadata_view, out);
+    NANOARROW_DCHECK(chars_written == metadata_size);
   }
 
-  result = GeoArrowMetadataSerializeInternal(metadata_view, &buffer);
-  if (result != GEOARROW_OK) {
-    ArrowBufferReset(&buffer);
-    return -1;
+  // If there is room, write the null terminator
+  if (metadata_size < n) {
+    out[metadata_size] = '\0';
   }
 
-  int64_t size_needed = buffer.size_bytes;
-  int64_t n_copy;
-  if (n >= size_needed) {
-    n_copy = size_needed;
-  } else {
-    n_copy = n;
-  }
-
-  if (n_copy > 0) {
-    memcpy(out, buffer.data, n_copy);
-  }
-
-  if (n > size_needed) {
-    out[size_needed] = '\0';
-  }
-
-  ArrowBufferReset(&buffer);
-  return size_needed;
+  return metadata_size;
 }
 
 GeoArrowErrorCode GeoArrowSchemaSetMetadata(
@@ -517,4 +575,39 @@ int64_t GeoArrowUnescapeCrs(struct GeoArrowStringView crs, char* out, int64_t n)
   }
 
   return out_i;
+}
+
+static const char* kCrsWgs84 =
+    "{\"type\":\"GeographicCRS\",\"name\":\"WGS 84 "
+    "(CRS84)\",\"datum_ensemble\":{\"name\":\"World Geodetic System 1984 "
+    "ensemble\",\"members\":[{\"name\":\"World Geodetic System 1984 "
+    "(Transit)\",\"id\":{\"authority\":\"EPSG\",\"code\":1166}},{\"name\":\"World "
+    "Geodetic System 1984 "
+    "(G730)\",\"id\":{\"authority\":\"EPSG\",\"code\":1152}},{\"name\":\"World Geodetic "
+    "System 1984 "
+    "(G873)\",\"id\":{\"authority\":\"EPSG\",\"code\":1153}},{\"name\":\"World Geodetic "
+    "System 1984 "
+    "(G1150)\",\"id\":{\"authority\":\"EPSG\",\"code\":1154}},{\"name\":\"World Geodetic "
+    "System 1984 "
+    "(G1674)\",\"id\":{\"authority\":\"EPSG\",\"code\":1155}},{\"name\":\"World Geodetic "
+    "System 1984 "
+    "(G1762)\",\"id\":{\"authority\":\"EPSG\",\"code\":1156}},{\"name\":\"World Geodetic "
+    "System 1984 "
+    "(G2139)\",\"id\":{\"authority\":\"EPSG\",\"code\":1309}}],\"ellipsoid\":{\"name\":"
+    "\"WGS "
+    "84\",\"semi_major_axis\":6378137,\"inverse_flattening\":298.257223563},\"accuracy\":"
+    "\"2.0\",\"id\":{\"authority\":\"EPSG\",\"code\":6326}},\"coordinate_system\":{"
+    "\"subtype\":\"ellipsoidal\",\"axis\":[{\"name\":\"Geodetic "
+    "longitude\",\"abbreviation\":\"Lon\",\"direction\":\"east\",\"unit\":\"degree\"},{"
+    "\"name\":\"Geodetic "
+    "latitude\",\"abbreviation\":\"Lat\",\"direction\":\"north\",\"unit\":\"degree\"}]},"
+    "\"scope\":\"Not "
+    "known.\",\"area\":\"World.\",\"bbox\":{\"south_latitude\":-90,\"west_longitude\":-"
+    "180,\"north_latitude\":90,\"east_longitude\":180},\"id\":{\"authority\":\"OGC\","
+    "\"code\":\"CRS84\"}}";
+
+void GeoArrowMetadataSetLonLat(struct GeoArrowMetadataView* metadata_view) {
+  metadata_view->crs.data = kCrsWgs84;
+  metadata_view->crs.size_bytes = strlen(kCrsWgs84);
+  metadata_view->crs_type = GEOARROW_CRS_TYPE_PROJJSON;
 }

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -11,61 +11,6 @@
     return EINVAL;                                 \
   }
 
-// A early draft implementation used something like the Arrow C Data interface
-// metadata specification instead of JSON. To help with the transition, this
-// bit of code parses the original metadata format.
-static GeoArrowErrorCode GeoArrowMetadataViewInitDeprecated(
-    struct GeoArrowMetadataView* metadata_view) {
-  const char* metadata = metadata_view->metadata.data;
-  int32_t pos_max = (int32_t)metadata_view->metadata.size_bytes;
-  int32_t pos = 0;
-  int32_t name_len;
-  int32_t value_len;
-  int32_t m;
-
-  CHECK_POS(sizeof(int32_t));
-  memcpy(&m, metadata + pos, sizeof(int32_t));
-  pos += sizeof(int32_t);
-
-  for (int j = 0; j < m; j++) {
-    CHECK_POS(sizeof(int32_t));
-    memcpy(&name_len, metadata + pos, sizeof(int32_t));
-    pos += sizeof(int32_t);
-
-    CHECK_POS(name_len)
-    const char* name = metadata + pos;
-    pos += name_len;
-
-    CHECK_POS(sizeof(int32_t))
-    memcpy(&value_len, metadata + pos, sizeof(int32_t));
-    pos += sizeof(int32_t);
-
-    CHECK_POS(value_len)
-    const char* value = metadata + pos;
-    pos += value_len;
-
-    if (name_len == 0 || value_len == 0) {
-      continue;
-    }
-
-    if (name_len == 3 && strncmp(name, "crs", 3) == 0) {
-      metadata_view->crs.size_bytes = value_len;
-      metadata_view->crs.data = value;
-      metadata_view->crs_type = GEOARROW_CRS_TYPE_UNKNOWN;
-    } else if (name_len == 5 && strncmp(name, "edges", 5) == 0) {
-      if (value_len == 9 && strncmp(value, "spherical", 9) == 0) {
-        metadata_view->edge_type = GEOARROW_EDGE_TYPE_SPHERICAL;
-      } else {
-        // unuspported value for 'edges' key
-      }
-    } else {
-      // unsupported metadata key
-    }
-  }
-
-  return GEOARROW_OK;
-}
-
 static int ParseChar(struct ArrowStringView* s, char c) {
   if (s->size_bytes > 0 && s->data[0] == c) {
     s->size_bytes--;
@@ -352,35 +297,7 @@ GeoArrowErrorCode GeoArrowMetadataViewInit(struct GeoArrowMetadataView* metadata
     return GEOARROW_OK;
   }
 
-  if (metadata.size_bytes >= 4 && metadata.data[0] != '{') {
-    if (GeoArrowMetadataViewInitDeprecated(metadata_view) == GEOARROW_OK) {
-      return GEOARROW_OK;
-    }
-  }
-
   return GeoArrowMetadataViewInitJSON(metadata_view, error);
-}
-
-static GeoArrowErrorCode GeoArrowMetadataSerializeInternalDeprecated(
-    const struct GeoArrowMetadataView* metadata_view, struct ArrowBuffer* buffer) {
-  switch (metadata_view->edge_type) {
-    case GEOARROW_EDGE_TYPE_SPHERICAL:
-      NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderAppend(buffer, ArrowCharView("edges"),
-                                                         ArrowCharView("spherical")));
-      break;
-    default:
-      break;
-  }
-
-  struct ArrowStringView crs_value;
-  if (metadata_view->crs.size_bytes > 0) {
-    crs_value.data = metadata_view->crs.data;
-    crs_value.size_bytes = metadata_view->crs.size_bytes;
-    NANOARROW_RETURN_NOT_OK(
-        ArrowMetadataBuilderAppend(buffer, ArrowCharView("crs"), crs_value));
-  }
-
-  return NANOARROW_OK;
 }
 
 static GeoArrowErrorCode GeoArrowMetadataSerializeInternal(
@@ -435,18 +352,11 @@ static GeoArrowErrorCode GeoArrowMetadataSerializeInternal(
 }
 
 static GeoArrowErrorCode GeoArrowSchemaSetMetadataInternal(
-    struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view,
-    int use_deprecated) {
+    struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view) {
   struct ArrowBuffer buffer;
   ArrowBufferInit(&buffer);
 
-  int result = 0;
-  if (use_deprecated) {
-    result = GeoArrowMetadataSerializeInternalDeprecated(metadata_view, &buffer);
-  } else {
-    result = GeoArrowMetadataSerializeInternal(metadata_view, &buffer);
-  }
-
+  int result = GeoArrowMetadataSerializeInternal(metadata_view, &buffer);
   if (result != GEOARROW_OK) {
     ArrowBufferReset(&buffer);
     return result;
@@ -513,12 +423,7 @@ int64_t GeoArrowMetadataSerialize(const struct GeoArrowMetadataView* metadata_vi
 
 GeoArrowErrorCode GeoArrowSchemaSetMetadata(
     struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view) {
-  return GeoArrowSchemaSetMetadataInternal(schema, metadata_view, 0);
-}
-
-GeoArrowErrorCode GeoArrowSchemaSetMetadataDeprecated(
-    struct ArrowSchema* schema, const struct GeoArrowMetadataView* metadata_view) {
-  return GeoArrowSchemaSetMetadataInternal(schema, metadata_view, 1);
+  return GeoArrowSchemaSetMetadataInternal(schema, metadata_view);
 }
 
 GeoArrowErrorCode GeoArrowSchemaSetMetadataFrom(struct ArrowSchema* schema,

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -194,7 +194,7 @@ TEST(MetadataTest, MetadataTestSetMetadata) {
 
   metadata_view.crs.data = "{}";
   metadata_view.crs.size_bytes = 2;
-  metadata_view.crs_type = GEOARROW_CRS_TYPE_PROJJSON;
+  metadata_view.crs_type = GEOARROW_CRS_TYPE_UNKNOWN;
   ASSERT_EQ(GeoArrowSchemaSetMetadata(&schema, &metadata_view), GEOARROW_OK);
   ASSERT_EQ(GeoArrowSchemaViewInit(&schema_view, &schema, NULL), GEOARROW_OK);
   std::string metadata_json = std::string(schema_view.extension_metadata.data,
@@ -240,12 +240,13 @@ TEST(MetadataTest, MetadataTestWriteJSON) {
 
   metadata_view.crs.data = "{}";
   metadata_view.crs.size_bytes = 2;
-  metadata_view.crs_type = GEOARROW_CRS_TYPE_PROJJSON;
+  metadata_view.crs_type = GEOARROW_CRS_TYPE_UNKNOWN;
   EXPECT_EQ(GeoArrowMetadataSerialize(&metadata_view, nullptr, 0), 30);
   EXPECT_EQ(GeoArrowMetadataSerialize(&metadata_view, out, sizeof(out)), 30);
   EXPECT_STREQ(out, "{\"edges\":\"spherical\",\"crs\":{}}");
 
   metadata_view.edge_type = GEOARROW_EDGE_TYPE_PLANAR;
+  metadata_view.crs_type = GEOARROW_CRS_TYPE_UNKNOWN;
   EXPECT_EQ(GeoArrowMetadataSerialize(&metadata_view, nullptr, 0), 10);
   EXPECT_EQ(GeoArrowMetadataSerialize(&metadata_view, out, sizeof(out)), 10);
   EXPECT_STREQ(out, "{\"crs\":{}}");

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -1,6 +1,4 @@
 
-#include <stdexcept>
-
 #include <gtest/gtest.h>
 
 #include <geoarrow.h>
@@ -17,43 +15,6 @@ TEST(MetadataTest, MetadataTestEmpty) {
   EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_NONE);
   EXPECT_EQ(metadata_view.crs.data, nullptr);
   EXPECT_EQ(metadata_view.crs.size_bytes, 0);
-}
-
-TEST(MetadataTest, MetadataTestSetMetadataDeprecated) {
-  // (test will only work on little endian)
-  char simple_metadata[] = {'\2', '\0', '\0', '\0', '\5', '\0', '\0', '\0', 'e', 'd', 'g',
-                            'e',  's',  '\t', '\0', '\0', '\0', 's',  'p',  'h', 'e', 'r',
-                            'i',  'c',  'a',  'l',  '\3', '\0', '\0', '\0', 'c', 'r', 's',
-                            '\6', '\0', '\0', '\0', 'c',  'r',  's',  'v',  'a', 'l'};
-  struct GeoArrowError error;
-  struct GeoArrowMetadataView metadata_view;
-  struct GeoArrowStringView metadata;
-  metadata.data = simple_metadata;
-
-  // Make sure all the buffer range checks work
-  for (int64_t i = 1; i < sizeof(simple_metadata); i++) {
-    metadata.size_bytes = i;
-    EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), EINVAL);
-  }
-
-  metadata.size_bytes = sizeof(simple_metadata);
-
-  EXPECT_EQ(GeoArrowMetadataViewInit(&metadata_view, metadata, &error), GEOARROW_OK);
-  EXPECT_EQ(metadata_view.edge_type, GEOARROW_EDGE_TYPE_SPHERICAL);
-  EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_UNKNOWN);
-  EXPECT_EQ(std::string(metadata_view.crs.data, metadata_view.crs.size_bytes), "crsval");
-
-  struct ArrowSchema schema;
-  ASSERT_EQ(GeoArrowSchemaInitExtension(&schema, GEOARROW_TYPE_WKB), GEOARROW_OK);
-  ASSERT_EQ(GeoArrowSchemaSetMetadataDeprecated(&schema, &metadata_view), GEOARROW_OK);
-
-  struct GeoArrowSchemaView schema_view;
-  ASSERT_EQ(GeoArrowSchemaViewInit(&schema_view, &schema, NULL), GEOARROW_OK);
-
-  EXPECT_EQ(memcmp(schema_view.extension_metadata.data, simple_metadata,
-                   sizeof(simple_metadata)),
-            0);
-  schema.release(&schema);
 }
 
 TEST(MetadataTest, MetadataTestReadJSONParsing) {


### PR DESCRIPTION
This PR add support for the `crs_type` key that was added in recent PRs to the GeoArrow spec. We already had a `GeoArrowCrsType` enum which simplifies things considerably; however, we'd been guessing its value from the first character of the CRS. In this PR we stop doing that but parse the value of `crs_type` and pass it on.

In doing this, I also improved the serialization and deserialization code, added a canonical "lonlat" setter, and generally improved the tests for metadata serialization/deserialization.