### PR TITLE
Improve compute function FFI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,11 @@ set(GEOARROW_SOURCES
     src/geoarrow/array_writer.c)
 
 set(GEOARROW_PUBLIC_HEADERS
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/geoarrow_config.h src/geoarrow/geoarrow_type.h
-    src/geoarrow/geoarrow.h src/geoarrow/geoarrow_type_inline.h)
+    ${CMAKE_CURRENT_BINARY_DIR}/generated/geoarrow_config.h
+    src/geoarrow/geoarrow_ffi.h
+    src/geoarrow/geoarrow_type.h
+    src/geoarrow/geoarrow.h
+    src/geoarrow/geoarrow_type_inline.h)
 
 if(GEOARROW_BUNDLE)
   # Bundle sources + headers, and if building tests, add a target the tests can link against

--- a/src/geoarrow/geoarrow_ffi.h
+++ b/src/geoarrow/geoarrow_ffi.h
@@ -1,0 +1,146 @@
+
+#ifndef GEOARROW_FFI_INCLUDED
+#define GEOARROW_FFI_INCLUDED
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Extra guard for versions of Arrow without the canonical guard
+#ifndef ARROW_FLAG_DICTIONARY_ORDERED
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+  // Array type description
+  const char* format;
+  const char* name;
+  const char* metadata;
+  int64_t flags;
+  int64_t n_children;
+  struct ArrowSchema** children;
+  struct ArrowSchema* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowSchema*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+struct ArrowArray {
+  // Array data description
+  int64_t length;
+  int64_t null_count;
+  int64_t offset;
+  int64_t n_buffers;
+  int64_t n_children;
+  const void** buffers;
+  struct ArrowArray** children;
+  struct ArrowArray* dictionary;
+
+  // Release callback
+  void (*release)(struct ArrowArray*);
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_DATA_INTERFACE
+
+#ifndef ARROW_C_STREAM_INTERFACE
+#define ARROW_C_STREAM_INTERFACE
+
+struct ArrowArrayStream {
+  // Callback to get the stream type
+  // (will be the same for all arrays in the stream).
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowSchema must be released independently from the stream.
+  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
+
+  // Callback to get the next array
+  // (if no error and the array is released, the stream has ended)
+  //
+  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
+  //
+  // If successful, the ArrowArray must be released independently from the stream.
+  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
+
+  // Callback to get optional detailed error information.
+  // This must only be called if the last stream operation failed
+  // with a non-0 return code.
+  //
+  // Return value: pointer to a null-terminated character array describing
+  // the last error, or NULL if no description is available.
+  //
+  // The returned pointer is only valid until the next operation on this stream
+  // (including release).
+  const char* (*get_last_error)(struct ArrowArrayStream*);
+
+  // Release callback: release the stream's own resources.
+  // Note that arrays returned by `get_next` must be individually released.
+  void (*release)(struct ArrowArrayStream*);
+
+  // Opaque producer-specific data
+  void* private_data;
+};
+
+#endif  // ARROW_C_STREAM_INTERFACE
+#endif  // ARROW_FLAG_DICTIONARY_ORDERED
+
+typedef int GeoArrowFFIErrorCode;
+
+struct GeoArrowFFIAllocator {
+  GeoArrowFFIErrorCode (*reallocate)(struct GeoArrowFFIAllocator* self, uint8_t** ptr,
+                                     int64_t old_size, int64_t new_size);
+  void (*free)(struct GeoArrowFFIAllocator* self, uint8_t* ptr, int64_t old_size);
+  void (*release)(struct GeoArrowFFIAllocator* self);
+  void* private_data;
+};
+
+struct GeoArrowFFIArg {
+  struct ArrowSchema* schema;
+  struct ArrowArray* value;
+};
+
+struct GeoArrowFFIFunctionState {
+  GeoArrowFFIErrorCode (*set_allocator)(GeoArrowFFIFunctionState* data);
+  GeoArrowFFIErrorCode (*push_view)(GeoArrowFFIFunctionState* data,
+                                    const ArrowArray* array, int64_t n_arrays);
+  GeoArrowFFIErrorCode (*push_owned)(GeoArrowFFIFunctionState* data, ArrowArray* array,
+                                     int64_t n_arrays);
+  GeoArrowFFIErrorCode (*pull)(GeoArrowFFIFunctionState* data, struct ArrowArray* out);
+  const char* (*get_last_error)(struct GeoArrowFFIFunctionState* data);
+  void (*release)(struct GeoArrowFFIFunctionState* self);
+  void* private_data;
+};
+
+struct GeoArrowFFIFunction {
+  GeoArrowFFIErrorCode (*set_option)(struct GeoArrowFFIFunction* self, const char* key,
+                                     const char* value);
+  GeoArrowFFIErrorCode (*get_option)(struct GeoArrowFFIFunction* self, const char* key,
+                                     const char** out_value);
+
+  GeoArrowFFIErrorCode (*bind)(struct GeoArrowFFIFunction* self,
+                               const struct GeoArrowFFIArgument* args, int64_t n_args,
+                               const struct ArrowSchema** out_type,
+                               struct GeoArrowFFIFunctionState* function_data_out);
+
+  const char* (*get_last_error)(struct GeoArrowFFIFunction* self);
+
+  void (*release)(struct GeoArrowFFIFunction* self);
+  void* private_data;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/geoarrow/geoarrow_ffi.h
+++ b/src/geoarrow/geoarrow_ffi.h
@@ -105,17 +105,10 @@ struct GeoArrowFFIAllocator {
   void* private_data;
 };
 
-struct GeoArrowFFIArg {
-  struct ArrowSchema* schema;
-  struct ArrowArray* value;
-};
-
 struct GeoArrowFFIFunctionState {
   GeoArrowFFIErrorCode (*set_allocator)(GeoArrowFFIFunctionState* data);
-  GeoArrowFFIErrorCode (*push_view)(GeoArrowFFIFunctionState* data,
-                                    const ArrowArray* array, int64_t n_arrays);
-  GeoArrowFFIErrorCode (*push_owned)(GeoArrowFFIFunctionState* data, ArrowArray* array,
-                                     int64_t n_arrays);
+  GeoArrowFFIErrorCode (*push)(GeoArrowFFIFunctionState* data, ArrowArray* array,
+                               int64_t n_arrays);
   GeoArrowFFIErrorCode (*pull)(GeoArrowFFIFunctionState* data, struct ArrowArray* out);
   const char* (*get_last_error)(struct GeoArrowFFIFunctionState* data);
   void (*release)(struct GeoArrowFFIFunctionState* self);
@@ -123,18 +116,12 @@ struct GeoArrowFFIFunctionState {
 };
 
 struct GeoArrowFFIFunction {
-  GeoArrowFFIErrorCode (*set_option)(struct GeoArrowFFIFunction* self, const char* key,
-                                     const char* value);
-  GeoArrowFFIErrorCode (*get_option)(struct GeoArrowFFIFunction* self, const char* key,
-                                     const char** out_value);
-
   GeoArrowFFIErrorCode (*bind)(struct GeoArrowFFIFunction* self,
-                               const struct GeoArrowFFIArgument* args, int64_t n_args,
-                               const struct ArrowSchema** out_type,
+                               const struct ArrowSchema** args, int64_t n_args,
+                               const char* metadata, struct ArrowSchema* out_type,
                                struct GeoArrowFFIFunctionState* function_data_out);
 
   const char* (*get_last_error)(struct GeoArrowFFIFunction* self);
-
   void (*release)(struct GeoArrowFFIFunction* self);
   void* private_data;
 };

--- a/src/geoarrow/geoarrow_ffi.h
+++ b/src/geoarrow/geoarrow_ffi.h
@@ -95,36 +95,150 @@ struct ArrowArrayStream {
 #endif  // ARROW_C_STREAM_INTERFACE
 #endif  // ARROW_FLAG_DICTIONARY_ORDERED
 
+/// \defgroup geoarrow-ffi GeoArrow ABI-Stable structures
+///
+/// This header provides the ABI-stable structures used for within-process
+/// interoperability among GeoArrow implementations.
+///
+/// @{
+
+/// \brief An errno-compatbile error code
 typedef int GeoArrowFFIErrorCode;
 
+/// \brief An allocator to use for large allocations
+///
+/// Most engines track memory usage very closely and provide a custom allocator
+/// to maximize performance. This structure allows the engine to specify how
+/// array buffers or other large intermediary buffers should be allocated.
 struct GeoArrowFFIAllocator {
+  /// \brief Allocate a new buffer or reallocate an old one
+  ///
+  /// New buffers are requested by ptr pointing to NULL and old_size equal to zero.
   GeoArrowFFIErrorCode (*reallocate)(struct GeoArrowFFIAllocator* self, uint8_t** ptr,
                                      int64_t old_size, int64_t new_size);
+
+  /// \brief Free a buffer allocated by reallocate
   void (*free)(struct GeoArrowFFIAllocator* self, uint8_t* ptr, int64_t old_size);
+
+  /// \brief Clone this allocator
+  ///
+  /// This will get
+  GeoArrowFFIErrorCode (*clone)(GeoArrowFFIAllocator* data, GeoArrowFFIAllocator* copy);
+
+  /// \brief Release any resources associated with this allocator and set the release
+  /// callback to NULL.
   void (*release)(struct GeoArrowFFIAllocator* self);
+
+  /// \brief Opaque, implementation-specific data
   void* private_data;
 };
 
+/// \brief State tracking a specific call to a function
+///
+/// Specifically, this is the result of a call to "bind" (i.e., input types
+/// and/or constant options are already known when this object is instantiated).
+/// The callbacks provided by this object perform the actual computation.
+/// Calls to these callbacks must be serialized/occur from the same thread; however,
+/// a clone callback is provided for cases where the engine cannot meet this guarantee.
 struct GeoArrowFFIFunctionState {
+  /// \brief Set the allocator that should be used for buffer allocations
+  ///
+  /// Implementations are not required to implement this callback but not doing
+  /// so may result in unexpected out-of-memory or degraded performance when used
+  /// with an engine that expects its use.
   GeoArrowFFIErrorCode (*set_allocator)(GeoArrowFFIFunctionState* data);
-  GeoArrowFFIErrorCode (*push)(GeoArrowFFIFunctionState* data, ArrowArray* array,
-                               int64_t n_arrays);
-  GeoArrowFFIErrorCode (*pull)(GeoArrowFFIFunctionState* data, struct ArrowArray* out);
+
+  /// \brief Populate an independent clone of this state that can be used concurrently
+  ///
+  /// Most engines do not organize their user-defined function interface in such a
+  /// way that batch calls are guaranteed to occur on the same thread. In this case,
+  /// an engine can clone a reference instance on each batch and use it to perform
+  /// the computation. Because of this, implementations of this callback should be
+  /// cheap.
+  GeoArrowFFIErrorCode (*clone)(GeoArrowFFIFunctionState* data,
+                                GeoArrowFFIFunctionState* copy);
+
+  /// \brief Push a batch of arguments into the compute function
+  ///
+  /// The arrays are interpreted according to the ArrowSchemas that were provided to the
+  /// bind callback that produced this state. The implementation should not perform
+  /// any computations in this step other than validating the structure of the input.
+  ///
+  /// Implementations for some functions may allow more than one batch to be pushed before
+  /// a call to pull; however, the canonical pattern for simple scalar functions
+  /// is a single pair of push/pull for each batch.
+  ///
+  /// The input arrays must have length of n_rows or 1. Constant values should be
+  /// represented by an array of length 1.
+  GeoArrowFFIErrorCode (*push)(GeoArrowFFIFunctionState* data, ArrowArray** arrays,
+                               int64_t n_arrays, int64_t n_rows);
+
+  /// \brief Compute and retrieve results of a calling the function
+  ///
+  /// Perform computation and pull n_rows of result into out (or a released out
+  /// to indicate there is no more output until another call to push).
+  GeoArrowFFIErrorCode (*pull)(GeoArrowFFIFunctionState* data, struct ArrowArray* out,
+                               int64_t n_rows);
+
+  /// \brief Retrieve a detailed error message from a previous erroring callback
+  ///
+  /// The result is valid until the next call to any callback, including release.
   const char* (*get_last_error)(struct GeoArrowFFIFunctionState* data);
+
+  /// \brief Release any resources associated with this state and set the release
+  /// callback to NULL.
   void (*release)(struct GeoArrowFFIFunctionState* self);
+
+  /// \brief Opaque, implementation-specific data
   void* private_data;
 };
 
+/// \brief An instance of a compute function
+///
+/// Typically there will be one instance of this object in some global registry
+/// wrapped in the engine's function registry as a user-defined function of some
+/// kind.
 struct GeoArrowFFIFunction {
+  /// \brief Bind a new instance of a GeoArrowFFIFunctionState and compute the output type
+  ///
+  /// This callback must be thread safe and reentrant (i.e., it can be called concurrently
+  /// from more than one thread at a time to produce independent function states).
   GeoArrowFFIErrorCode (*bind)(struct GeoArrowFFIFunction* self,
-                               const struct ArrowSchema** args, int64_t n_args,
-                               const char* metadata, struct ArrowSchema* out_type,
-                               struct GeoArrowFFIFunctionState* function_data_out);
+                               struct ArrowSchema** args, int64_t n_args,
+                               const char* options, struct ArrowSchema* out_schema,
+                               struct GeoArrowFFIFunctionState* out_function_data);
 
+  /// \brief Retrieve a detailed error message from a previous erroring callback
+  ///
+  /// The result is valid until the next call to any callback, including release.
   const char* (*get_last_error)(struct GeoArrowFFIFunction* self);
+
+  /// \brief Release any resources associated with this state and set the release
+  /// callback to NULL.
   void (*release)(struct GeoArrowFFIFunction* self);
+
+  /// \brief Opaque, implementation-specific data
   void* private_data;
 };
+
+struct GeoArrowFFICatalog {
+  GeoArrowFFIErrorCode get_function(const char* name, const char* options,
+                                    struct GeoArrowFFIFunction* out_function);
+
+  /// \brief Retrieve a detailed error message from a previous erroring callback
+  ///
+  /// The result is valid until the next call to any callback, including release.
+  const char* (*get_last_error)(struct GeoArrowFFIFunction* self);
+
+  /// \brief Release any resources associated with this catalog and set the release
+  /// callback to NULL.
+  void (*release)(struct GeoArrowFFICatalog* self);
+
+  /// \brief Opaque, implementation-specific data
+  void* private_data;
+};
+
+/// @}
 
 #ifdef __cplusplus
 }

--- a/src/geoarrow/geoarrow_ffi.h
+++ b/src/geoarrow/geoarrow_ffi.h
@@ -37,7 +37,7 @@ typedef int GeoArrowErrorCode;
 ///
 /// A function requested from a GeoArrowFFICatalog with this value must implement a
 /// GeoArrowFFIFunctionState whose pull callback always returns an ArrowArray with
-/// a single row regardless of the number of preceeding pull calls.
+/// a single row regardless of the number of preceding pull calls.
 #define GEOARROW_FFI_FUNCTION_TYPE_ACCUMULATOR 2
 
 /// \brief A function whose output does not depend on the size of the input

--- a/src/geoarrow/geoarrow_ffi.h
+++ b/src/geoarrow/geoarrow_ffi.h
@@ -166,7 +166,8 @@ struct GeoArrowFFIAllocator {
   /// \brief Clone this allocator
   ///
   /// This will get
-  GeoArrowErrorCode (*clone)(GeoArrowFFIAllocator* data, GeoArrowFFIAllocator* copy);
+  GeoArrowErrorCode (*clone)(struct GeoArrowFFIAllocator* data,
+                             struct GeoArrowFFIAllocator* copy);
 
   /// \brief Release any resources associated with this allocator and set the release
   /// callback to NULL.
@@ -190,7 +191,7 @@ struct GeoArrowFFIFunctionState {
   /// Implementations are not required to implement this callback but not doing
   /// so may result in unexpected out-of-memory or degraded performance when used
   /// with an engine that expects its use.
-  GeoArrowErrorCode (*set_allocator)(GeoArrowFFIFunctionState* data);
+  GeoArrowErrorCode (*set_allocator)(struct GeoArrowFFIFunctionState* data);
 
   /// \brief Populate an independent clone of this state that can be used concurrently
   ///
@@ -199,8 +200,8 @@ struct GeoArrowFFIFunctionState {
   /// an engine can clone a reference instance on each batch and use it to perform
   /// the computation. Because of this, implementations of this callback should be
   /// cheap.
-  GeoArrowErrorCode (*clone)(GeoArrowFFIFunctionState* data,
-                             GeoArrowFFIFunctionState* copy);
+  GeoArrowErrorCode (*clone)(struct GeoArrowFFIFunctionState* data,
+                             struct GeoArrowFFIFunctionState* copy);
 
   /// \brief Push a batch of arguments into the compute function
   ///
@@ -214,14 +215,14 @@ struct GeoArrowFFIFunctionState {
   ///
   /// The input arrays must have length of n_rows or 1. Constant values should be
   /// represented by an array of length 1.
-  GeoArrowErrorCode (*push)(GeoArrowFFIFunctionState* data, ArrowArray** arrays,
-                            int64_t n_arrays, int64_t n_rows);
+  GeoArrowErrorCode (*push)(struct GeoArrowFFIFunctionState* data,
+                            struct ArrowArray** arrays, int64_t n_arrays, int64_t n_rows);
 
   /// \brief Compute and retrieve results of a calling the function
   ///
   /// Perform computation and pull n_rows of result into out (or a released out
   /// to indicate there is no more output until another call to push).
-  GeoArrowErrorCode (*pull)(GeoArrowFFIFunctionState* data, struct ArrowArray* out,
+  GeoArrowErrorCode (*pull)(struct GeoArrowFFIFunctionState* data, struct ArrowArray* out,
                             int64_t n_rows);
 
   /// \brief Retrieve a detailed error message from a previous erroring callback
@@ -276,8 +277,9 @@ struct GeoArrowFFICatalog {
   /// The function_type parameter corresponds to the GEOARROW_FFI_FUNCTION_TYPE_*
   /// definitions above; options are packed in the same way as the ArrowSchema::metadata
   /// field.
-  GeoArrowErrorCode get_function(int function_type, const char* name, const char* options,
-                                 struct GeoArrowFFIFunction* out_function);
+  GeoArrowErrorCode (*get_function)(int function_type, const char* name,
+                                    const char* options,
+                                    struct GeoArrowFFIFunction* out_function);
 
   /// \brief Retrieve a detailed error message from a previous erroring callback
   ///

--- a/src/geoarrow/geoarrow_type.h
+++ b/src/geoarrow/geoarrow_type.h
@@ -5,97 +5,11 @@
 #include <stdint.h>
 
 #include "geoarrow_config.h"
+#include "geoarrow_ffi.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// Extra guard for versions of Arrow without the canonical guard
-#ifndef ARROW_FLAG_DICTIONARY_ORDERED
-
-#ifndef ARROW_C_DATA_INTERFACE
-#define ARROW_C_DATA_INTERFACE
-
-#define ARROW_FLAG_DICTIONARY_ORDERED 1
-#define ARROW_FLAG_NULLABLE 2
-#define ARROW_FLAG_MAP_KEYS_SORTED 4
-
-struct ArrowSchema {
-  // Array type description
-  const char* format;
-  const char* name;
-  const char* metadata;
-  int64_t flags;
-  int64_t n_children;
-  struct ArrowSchema** children;
-  struct ArrowSchema* dictionary;
-
-  // Release callback
-  void (*release)(struct ArrowSchema*);
-  // Opaque producer-specific data
-  void* private_data;
-};
-
-struct ArrowArray {
-  // Array data description
-  int64_t length;
-  int64_t null_count;
-  int64_t offset;
-  int64_t n_buffers;
-  int64_t n_children;
-  const void** buffers;
-  struct ArrowArray** children;
-  struct ArrowArray* dictionary;
-
-  // Release callback
-  void (*release)(struct ArrowArray*);
-  // Opaque producer-specific data
-  void* private_data;
-};
-
-#endif  // ARROW_C_DATA_INTERFACE
-
-#ifndef ARROW_C_STREAM_INTERFACE
-#define ARROW_C_STREAM_INTERFACE
-
-struct ArrowArrayStream {
-  // Callback to get the stream type
-  // (will be the same for all arrays in the stream).
-  //
-  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
-  //
-  // If successful, the ArrowSchema must be released independently from the stream.
-  int (*get_schema)(struct ArrowArrayStream*, struct ArrowSchema* out);
-
-  // Callback to get the next array
-  // (if no error and the array is released, the stream has ended)
-  //
-  // Return value: 0 if successful, an `errno`-compatible error code otherwise.
-  //
-  // If successful, the ArrowArray must be released independently from the stream.
-  int (*get_next)(struct ArrowArrayStream*, struct ArrowArray* out);
-
-  // Callback to get optional detailed error information.
-  // This must only be called if the last stream operation failed
-  // with a non-0 return code.
-  //
-  // Return value: pointer to a null-terminated character array describing
-  // the last error, or NULL if no description is available.
-  //
-  // The returned pointer is only valid until the next operation on this stream
-  // (including release).
-  const char* (*get_last_error)(struct ArrowArrayStream*);
-
-  // Release callback: release the stream's own resources.
-  // Note that arrays returned by `get_next` must be individually released.
-  void (*release)(struct ArrowArrayStream*);
-
-  // Opaque producer-specific data
-  void* private_data;
-};
-
-#endif  // ARROW_C_STREAM_INTERFACE
-#endif  // ARROW_FLAG_DICTIONARY_ORDERED
 
 /// \brief Return code for success
 /// \ingroup geoarrow-utility
@@ -114,10 +28,6 @@ struct ArrowArrayStream {
 /// \ingroup geoarrow-utility
 #define GEOARROW_RETURN_NOT_OK(EXPR) \
   _GEOARROW_RETURN_NOT_OK_IMPL(_GEOARROW_MAKE_NAME(errno_status_, __COUNTER__), EXPR)
-
-/// \brief Represents an errno-compatible error code
-/// \ingroup geoarrow-utility
-typedef int GeoArrowErrorCode;
 
 struct GeoArrowError {
   char message[1024];


### PR DESCRIPTION
This should be able to export:

- DataFusion scalar function
- DataFusion table function
- Arrow C++ Scalar function
- Arrow C++ Aggregate function
- Any file reader that can export an ArrowArray
- A data source based on a SQL query + parameters from an AdbcConnection (with a lot of mutexes)

This should be able to be imported and used as a:

- DataFusion scalar function
- DataFusion table function
- Arrow C++ Scalar function
- DuckDB scalar function
- DuckDB table function

...obviously that needs some testing, but the concepts are intended to line up:

- "bind" / "return_type" / "KernelState::Resolver" == bind (computes output type from input type)
- Various combinations of clone/push/pull can accomodate per-batch computation (i.e., DataFusion's invoke_batch, DuckDB's "function") and aggregation of multiple batches into a single value (Arrow's ScalarAggregate function, DataFusion's accumulator, one stage of DuckDB's aggregator)
- Arrow C++-based and nanoarrow-based implementations should be able to respect the custom allocator; DuckDB and Arrow C++ should be able to provide the custom allocator (DataFusion doesn't have a non-default allocator that I could find documentation on)

This *doesn't* handle pre-allocated output (maybe DuckDB, Arrow C++). Most geo functions don't benefit from this anyway (very few fixed-width -> fixed width transformations that are cheap enough that they could reuse the input allocation).