### PR TITLE
feat: Add type traits to help resolve array and coordinate data types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ if(GEOARROW_BUILD_TESTS)
                  src/geoarrow/hpp/arrow_extension_type_test.cc)
   add_executable(hpp_array_util_test src/geoarrow/hpp/array_util_test.cc)
   add_executable(hpp_wkb_util_test src/geoarrow/hpp/wkb_util_test.cc)
+  add_executable(hpp_geometry_type_traits_test src/geoarrow/hpp/geometry_type_traits_test.cc)
 
   target_link_libraries(geoarrow_type_inline_test geoarrow gtest_main
                         nanoarrow::nanoarrow)
@@ -328,6 +329,11 @@ if(GEOARROW_BUILD_TESTS)
                         gtest_main
                         gmock_main
                         nanoarrow::nanoarrow)
+  target_link_libraries(hpp_geometry_type_traits_test
+                        geoarrow
+                        gtest_main
+                        gmock_main
+                        nanoarrow::nanoarrow)
 
   include(GoogleTest)
   gtest_discover_tests(geoarrow_type_inline_test)
@@ -353,4 +359,5 @@ if(GEOARROW_BUILD_TESTS)
   gtest_discover_tests(hpp_arrow_extension_type_test)
   gtest_discover_tests(hpp_array_util_test)
   gtest_discover_tests(hpp_wkb_util_test)
+  gtest_discover_tests(hpp_geometry_type_traits_test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,8 @@ if(GEOARROW_BUNDLE)
           array_reader.hpp
           array_writer.hpp
           array_util.hpp
-          wkb_util.hpp)
+          wkb_util.hpp
+          geometry_type_traits.hpp)
     file(READ "src/geoarrow/hpp/${SRC_FILE}" SRC_FILE_CONTENTS)
     file(APPEND ${GEOARROW_HPP_TEMP} "${SRC_FILE_CONTENTS}")
   endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 if(GEOARROW_USE_FAST_FLOAT)
   if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
   endif()
 
   set(GEOARROW_DOUBLE_PARSE_SOURCE src/geoarrow/double_parse_fast_float.cc)
@@ -227,13 +227,7 @@ if(GEOARROW_BUILD_TESTS)
   include(FetchContent)
 
   find_package(Arrow REQUIRED)
-
-  if(${ARROW_VERSION} VERSION_GREATER_EQUAL "10.0.0")
-    set(CMAKE_CXX_STANDARD 17)
-  else()
-    set(CMAKE_CXX_STANDARD 11)
-  endif()
-
+  set(CMAKE_CXX_STANDARD 17)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
   if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.23")
@@ -289,7 +283,8 @@ if(GEOARROW_BUILD_TESTS)
                  src/geoarrow/hpp/arrow_extension_type_test.cc)
   add_executable(hpp_array_util_test src/geoarrow/hpp/array_util_test.cc)
   add_executable(hpp_wkb_util_test src/geoarrow/hpp/wkb_util_test.cc)
-  add_executable(hpp_geometry_type_traits_test src/geoarrow/hpp/geometry_type_traits_test.cc)
+  add_executable(hpp_geometry_type_traits_test
+                 src/geoarrow/hpp/geometry_type_traits_test.cc)
 
   target_link_libraries(geoarrow_type_inline_test geoarrow gtest_main
                         nanoarrow::nanoarrow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,7 @@ if(GEOARROW_BUNDLE)
           array_reader.hpp
           array_writer.hpp
           array_util.hpp
-          binary_util.hpp)
+          wkb_util.hpp)
     file(READ "src/geoarrow/hpp/${SRC_FILE}" SRC_FILE_CONTENTS)
     file(APPEND ${GEOARROW_HPP_TEMP} "${SRC_FILE_CONTENTS}")
   endforeach()
@@ -288,7 +288,7 @@ if(GEOARROW_BUILD_TESTS)
   add_executable(hpp_arrow_extension_type_test
                  src/geoarrow/hpp/arrow_extension_type_test.cc)
   add_executable(hpp_array_util_test src/geoarrow/hpp/array_util_test.cc)
-  add_executable(hpp_binary_util_test src/geoarrow/hpp/binary_util_test.cc)
+  add_executable(hpp_wkb_util_test src/geoarrow/hpp/wkb_util_test.cc)
 
   target_link_libraries(geoarrow_type_inline_test geoarrow gtest_main
                         nanoarrow::nanoarrow)
@@ -323,7 +323,7 @@ if(GEOARROW_BUILD_TESTS)
                         gtest_main
                         gmock_main
                         nanoarrow::nanoarrow)
-  target_link_libraries(hpp_binary_util_test
+  target_link_libraries(hpp_wkb_util_test
                         geoarrow
                         gtest_main
                         gmock_main
@@ -352,5 +352,5 @@ if(GEOARROW_BUILD_TESTS)
   gtest_discover_tests(hpp_geometry_data_type_test)
   gtest_discover_tests(hpp_arrow_extension_type_test)
   gtest_discover_tests(hpp_array_util_test)
-  gtest_discover_tests(hpp_binary_util_test)
+  gtest_discover_tests(hpp_wkb_util_test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,8 @@ if(GEOARROW_BUILD_TESTS)
                  src/geoarrow/hpp/arrow_extension_type_test.cc)
   add_executable(hpp_array_util_test src/geoarrow/hpp/array_util_test.cc)
   add_executable(hpp_wkb_util_test src/geoarrow/hpp/wkb_util_test.cc)
-  add_executable(hpp_geometry_type_traits_test src/geoarrow/hpp/geometry_type_traits_test.cc)
+  add_executable(hpp_geometry_type_traits_test
+                 src/geoarrow/hpp/geometry_type_traits_test.cc)
 
   target_link_libraries(geoarrow_type_inline_test geoarrow gtest_main
                         nanoarrow::nanoarrow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 if(GEOARROW_USE_FAST_FLOAT)
   if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD 11)
   endif()
 
   set(GEOARROW_DOUBLE_PARSE_SOURCE src/geoarrow/double_parse_fast_float.cc)
@@ -227,7 +227,13 @@ if(GEOARROW_BUILD_TESTS)
   include(FetchContent)
 
   find_package(Arrow REQUIRED)
-  set(CMAKE_CXX_STANDARD 17)
+
+  if(${ARROW_VERSION} VERSION_GREATER_EQUAL "10.0.0")
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
   if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.23")
@@ -283,8 +289,7 @@ if(GEOARROW_BUILD_TESTS)
                  src/geoarrow/hpp/arrow_extension_type_test.cc)
   add_executable(hpp_array_util_test src/geoarrow/hpp/array_util_test.cc)
   add_executable(hpp_wkb_util_test src/geoarrow/hpp/wkb_util_test.cc)
-  add_executable(hpp_geometry_type_traits_test
-                 src/geoarrow/hpp/geometry_type_traits_test.cc)
+  add_executable(hpp_geometry_type_traits_test src/geoarrow/hpp/geometry_type_traits_test.cc)
 
   target_link_libraries(geoarrow_type_inline_test geoarrow gtest_main
                         nanoarrow::nanoarrow)

--- a/src/geoarrow/geoarrow.hpp
+++ b/src/geoarrow/geoarrow.hpp
@@ -2,7 +2,7 @@
 #include "hpp/array_reader.hpp"
 #include "hpp/array_util.hpp"
 #include "hpp/array_writer.hpp"
-#include "hpp/binary_util.hpp"
 #include "hpp/exception.hpp"
 #include "hpp/geometry_data_type.hpp"
 #include "hpp/internal.hpp"
+#include "hpp/wkb_util.hpp"

--- a/src/geoarrow/geoarrow.hpp
+++ b/src/geoarrow/geoarrow.hpp
@@ -4,5 +4,6 @@
 #include "hpp/array_writer.hpp"
 #include "hpp/exception.hpp"
 #include "hpp/geometry_data_type.hpp"
+#include "hpp/geometry_type_traits.hpp"
 #include "hpp/internal.hpp"
 #include "hpp/wkb_util.hpp"

--- a/src/geoarrow/hpp/array_util.hpp
+++ b/src/geoarrow/hpp/array_util.hpp
@@ -876,6 +876,9 @@ struct ListSequence {
     }
   }
 
+  /// \brief Return the number of elements in the sequence
+  int64_t size() const { return length; }
+
   /// \brief Initialize a child whose offset and length are unset.
   void InitChild(T* child_p) const { *child_p = child; }
 

--- a/src/geoarrow/hpp/geometry_type_traits.hpp
+++ b/src/geoarrow/hpp/geometry_type_traits.hpp
@@ -125,8 +125,9 @@ struct TypeTraits<GEOARROW_TYPE_LARGE_WKB> {
 
 #define _GEOARROW_NATIVE_ARRAY_CALL_INTERNAL(geometry_type, dimensions, expr, ...)    \
   do {                                                                                \
-    using array_type_internal = typename ::geoarrow::type_traits::GeometryTypeTraits< \
-        GEOARROW_GEOMETRY_TYPE_POINT, GEOARROW_DIMENSIONS_XY>::array_type;            \
+    using array_type_internal =                                                       \
+        typename ::geoarrow::type_traits::GeometryTypeTraits<geometry_type,           \
+                                                             dimensions>::array_type; \
     array_type_internal array_instance_internal;                                      \
     expr(array_instance_internal, __VA_ARGS__);                                       \
   } while (false)
@@ -136,26 +137,60 @@ struct TypeTraits<GEOARROW_TYPE_LARGE_WKB> {
   do {                                                                                   \
     switch (dimensions) {                                                                \
       case GEOARROW_DIMENSIONS_XY:                                                       \
-        _GEOARROW_NATIVE_ARRAY_CALL_INTERNAL(geometry_type, dimensions, expr,            \
-                                             __VA_ARGS__);                               \
+        _GEOARROW_NATIVE_ARRAY_CALL_INTERNAL(geometry_type, GEOARROW_DIMENSIONS_XY,      \
+                                             expr, __VA_ARGS__);                         \
+        break;                                                                           \
+      case GEOARROW_DIMENSIONS_XYZ:                                                      \
+        _GEOARROW_NATIVE_ARRAY_CALL_INTERNAL(geometry_type, GEOARROW_DIMENSIONS_XYZ,     \
+                                             expr, __VA_ARGS__);                         \
+        break;                                                                           \
+      case GEOARROW_DIMENSIONS_XYM:                                                      \
+        _GEOARROW_NATIVE_ARRAY_CALL_INTERNAL(geometry_type, GEOARROW_DIMENSIONS_XYM,     \
+                                             expr, __VA_ARGS__);                         \
+        break;                                                                           \
+      case GEOARROW_DIMENSIONS_XYZM:                                                     \
+        _GEOARROW_NATIVE_ARRAY_CALL_INTERNAL(geometry_type, GEOARROW_DIMENSIONS_XYZM,    \
+                                             expr, __VA_ARGS__);                         \
         break;                                                                           \
       default:                                                                           \
         throw ::geoarrow::Exception("Unknown dimension type");                           \
     }                                                                                    \
   } while (false)
 
-#define GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(type_id, expr, ...)                    \
-  do {                                                                             \
-    auto geometry_type_internal = GeoArrowGeometryTypeFromType(type_id);           \
-    auto dimensions_internal = GeoArrowDimensionsFromType(type_id);                \
-    switch (geometry_type_internal) {                                              \
-      case GEOARROW_GEOMETRY_TYPE_POINT:                                           \
-        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                           \
-            GEOARROW_GEOMETRY_TYPE_POINT, dimensions_internal, expr, __VA_ARGS__); \
-        break;                                                                     \
-      default:                                                                     \
-        throw ::geoarrow::Exception("Unknown geometry type");                      \
-    }                                                                              \
+#define GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(type_id, expr, ...)                         \
+  do {                                                                                  \
+    auto geometry_type_internal = GeoArrowGeometryTypeFromType(type_id);                \
+    auto dimensions_internal = GeoArrowDimensionsFromType(type_id);                     \
+    switch (geometry_type_internal) {                                                   \
+      case GEOARROW_GEOMETRY_TYPE_POINT:                                                \
+        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                                \
+            GEOARROW_GEOMETRY_TYPE_POINT, dimensions_internal, expr, __VA_ARGS__);      \
+        break;                                                                          \
+      case GEOARROW_GEOMETRY_TYPE_LINESTRING:                                           \
+        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                                \
+            GEOARROW_GEOMETRY_TYPE_LINESTRING, dimensions_internal, expr, __VA_ARGS__); \
+        break;                                                                          \
+      case GEOARROW_GEOMETRY_TYPE_POLYGON:                                              \
+        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                                \
+            GEOARROW_GEOMETRY_TYPE_POLYGON, dimensions_internal, expr, __VA_ARGS__);    \
+        break;                                                                          \
+      case GEOARROW_GEOMETRY_TYPE_MULTIPOINT:                                           \
+        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                                \
+            GEOARROW_GEOMETRY_TYPE_MULTIPOINT, dimensions_internal, expr, __VA_ARGS__); \
+        break;                                                                          \
+      case GEOARROW_GEOMETRY_TYPE_MULTILINESTRING:                                      \
+        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                                \
+            GEOARROW_GEOMETRY_TYPE_MULTILINESTRING, dimensions_internal, expr,          \
+            __VA_ARGS__);                                                               \
+        break;                                                                          \
+      case GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON:                                         \
+        _GEOARROW_DISPATCH_NATIVE_ARRAY_CALL_DIMENSIONS(                                \
+            GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON, dimensions_internal, expr,             \
+            __VA_ARGS__);                                                               \
+        break;                                                                          \
+      default:                                                                          \
+        throw ::geoarrow::Exception("Unknown geometry type");                           \
+    }                                                                                   \
   } while (false)
 
 #endif

--- a/src/geoarrow/hpp/geometry_type_traits.hpp
+++ b/src/geoarrow/hpp/geometry_type_traits.hpp
@@ -10,6 +10,11 @@ namespace type_traits {
 
 namespace internal {
 
+/// \brief A template to resolve the coordinate type based on a dimensions constant
+///
+/// This may change in the future if more coordinate storage options are added
+/// (e.g., float) or if the coordinate sequence is updated such that the Coord level
+/// of templating is no longer needed.
 template <enum GeoArrowDimensions dimensions>
 struct DimensionTraits;
 
@@ -63,6 +68,8 @@ _GEOARROW_SPECIALIZE_GEOMETRY_TYPE(GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON,
 
 }  // namespace internal
 
+/// \brief Resolve compile-time type definitions and constants from a geometry type and
+/// dimension identifier.
 template <enum GeoArrowGeometryType geometry_type, enum GeoArrowDimensions dimensions>
 struct GeometryTypeTraits {
   using coord_type = typename internal::DimensionTraits<dimensions>::coord_type;
@@ -77,6 +84,7 @@ struct GeometryTypeTraits {
 
 };  // namespace type_traits
 
+/// \brief Resolve compile-time type definitions and constants from a type identifier
 template <enum GeoArrowType type>
 struct TypeTraits {
   static constexpr enum GeoArrowCoordType coord_type_id =
@@ -146,6 +154,13 @@ struct TypeTraits<GEOARROW_TYPE_LARGE_WKB> {
     }                                                                                    \
   } while (false)
 
+/// \brief Dispatch a call to a function accepting an Array specialization
+///
+/// This allows writing generic code against any Array type in the form
+/// `template <typename Array> DoSomething(Array& array, ...) { ... }`, which can be
+/// dispatched using `GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(type_id, DoSomething, ...);`.
+/// Currently requires that `DoSomething` handles all native array types and accepts
+/// a parameter other than array (e.g., a `GeoArrowArrayView`).
 #define GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(type_id, expr, ...)                         \
   do {                                                                                  \
     auto geometry_type_internal = GeoArrowGeometryTypeFromType(type_id);                \

--- a/src/geoarrow/hpp/geometry_type_traits.hpp
+++ b/src/geoarrow/hpp/geometry_type_traits.hpp
@@ -1,7 +1,6 @@
 #ifndef GEOARROW_HPP_TYPE_TRAITS_INCLUDED
 #define GEOARROW_HPP_TYPE_TRAITS_INCLUDED
 
-#include "geoarrow.h"
 #include "hpp/array_util.hpp"
 #include "hpp/wkb_util.hpp"
 

--- a/src/geoarrow/hpp/geometry_type_traits.hpp
+++ b/src/geoarrow/hpp/geometry_type_traits.hpp
@@ -58,6 +58,9 @@ _GEOARROW_SPECIALIZE_GEOMETRY_TYPE(GEOARROW_GEOMETRY_TYPE_MULTILINESTRING,
 _GEOARROW_SPECIALIZE_GEOMETRY_TYPE(GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON,
                                    MultiPolygonArray);
 
+#undef _GEOARROW_SPECIALIZE_GEOMETRY_TYPE
+#undef _GEOARROW_SPECIALIZE_ARRAY_TYPE
+
 }  // namespace internal
 
 template <enum GeoArrowGeometryType geometry_type, enum GeoArrowDimensions dimensions>

--- a/src/geoarrow/hpp/geometry_type_traits.hpp
+++ b/src/geoarrow/hpp/geometry_type_traits.hpp
@@ -1,0 +1,107 @@
+#ifndef GEOARROW_HPP_TYPE_TRAITS_INCLUDED
+#define GEOARROW_HPP_TYPE_TRAITS_INCLUDED
+
+#include "geoarrow.h"
+#include "hpp/array_util.hpp"
+#include "hpp/wkb_util.hpp"
+
+namespace geoarrow {
+
+namespace type_traits {
+
+template <enum GeoArrowDimensions dimensions>
+struct DimensionTraits;
+
+template <>
+struct DimensionTraits<GEOARROW_DIMENSIONS_XY> {
+  using coord_type = array_util::XY<double>;
+};
+
+template <>
+struct DimensionTraits<GEOARROW_DIMENSIONS_XYZ> {
+  using coord_type = array_util::XYZ<double>;
+};
+
+template <>
+struct DimensionTraits<GEOARROW_DIMENSIONS_XYM> {
+  using coord_type = array_util::XYM<double>;
+};
+
+template <>
+struct DimensionTraits<GEOARROW_DIMENSIONS_XYZM> {
+  using coord_type = array_util::XYZM<double>;
+};
+
+template <enum GeoArrowDimensions dimensions_id>
+struct ResolveArrayType {
+  using coord_type = typename DimensionTraits<dimensions_id>::coord_type;
+
+  template <enum GeoArrowGeometryType geometry_type>
+  struct Inner;
+
+  template <>
+  struct Inner<GEOARROW_GEOMETRY_TYPE_POINT> {
+    using array_type = array_util::PointArray<coord_type>;
+  };
+
+  template <>
+  struct Inner<GEOARROW_GEOMETRY_TYPE_LINESTRING> {
+    using array_type = array_util::LinestringArray<coord_type>;
+  };
+
+  template <>
+  struct Inner<GEOARROW_GEOMETRY_TYPE_POLYGON> {
+    using array_type = array_util::PolygonArray<coord_type>;
+  };
+
+  template <>
+  struct Inner<GEOARROW_GEOMETRY_TYPE_MULTIPOINT> {
+    using array_type = array_util::MultipointArray<coord_type>;
+  };
+
+  template <>
+  struct Inner<GEOARROW_GEOMETRY_TYPE_MULTILINESTRING> {
+    using array_type = array_util::MultiLinestringArray<coord_type>;
+  };
+
+  template <>
+  struct Inner<GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON> {
+    using array_type = array_util::MultiPolygonArray<coord_type>;
+  };
+};
+
+template <enum GeoArrowType type>
+struct TypeTraits {
+  static constexpr enum GeoArrowCoordType coord_type_id =
+      static_cast<enum GeoArrowCoordType>(type / 10000 + 1);
+  static constexpr enum GeoArrowDimensions dimensions_id =
+      static_cast<enum GeoArrowDimensions>((type % 10000) / 1000 + 1);
+  static constexpr enum GeoArrowGeometryType geometry_type_id =
+      static_cast<enum GeoArrowGeometryType>((type % 10000) % 1000);
+
+  using coord_type = typename DimensionTraits<dimensions_id>::coord_type;
+  using sequence_type = array_util::CoordSequence<coord_type>;
+  using array_type = typename ResolveArrayType<dimensions_id>::template Inner<
+      geometry_type_id>::array_type;
+};
+
+template <>
+struct TypeTraits<GEOARROW_TYPE_WKT> {};
+
+template <>
+struct TypeTraits<GEOARROW_TYPE_LARGE_WKT> {};
+
+template <>
+struct TypeTraits<GEOARROW_TYPE_WKB> {
+  using array_type = wkb_util::WKBArray<int32_t>;
+};
+
+template <>
+struct TypeTraits<GEOARROW_TYPE_LARGE_WKB> {
+  using array_type = wkb_util::WKBArray<int64_t>;
+};
+}  // namespace type_traits
+
+}  // namespace geoarrow
+
+#endif

--- a/src/geoarrow/hpp/geometry_type_traits_test.cc
+++ b/src/geoarrow/hpp/geometry_type_traits_test.cc
@@ -7,11 +7,15 @@
 #include "geoarrow.hpp"
 #include "geometry_type_traits.hpp"
 
-namespace geoarrow::type_traits {
-
-TEST(GeoArrowHppTest, GeometryTypeTraits) {
-  using array_type = typename TypeTraits<GEOARROW_TYPE_POINT>::array_type;
-  ASSERT_EQ(array_type::geometry_type, GEOARROW_GEOMETRY_TYPE_POINT);
+template <typename Array>
+void DoSomethingWithArray(const Array& array, bool* was_called = nullptr) {
+  EXPECT_EQ(array.value.size(), 0);
+  *was_called = true;
 }
 
-}  // namespace geoarrow::type_traits
+TEST(GeoArrowHppTest, DispatchNativeArray) {
+  bool was_called = false;
+  GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(GEOARROW_TYPE_POINT, DoSomethingWithArray,
+                                      &was_called);
+  EXPECT_TRUE(was_called);
+}

--- a/src/geoarrow/hpp/geometry_type_traits_test.cc
+++ b/src/geoarrow/hpp/geometry_type_traits_test.cc
@@ -5,7 +5,6 @@
 #include "nanoarrow/nanoarrow.h"
 
 #include "geoarrow.hpp"
-#include "geometry_type_traits.hpp"
 #include "wkx_testing.hpp"
 
 template <typename Array>

--- a/src/geoarrow/hpp/geometry_type_traits_test.cc
+++ b/src/geoarrow/hpp/geometry_type_traits_test.cc
@@ -14,6 +14,22 @@ void DoSomethingWithArray(const Array& array, bool* was_called,
   EXPECT_EQ(array.value.size(), 0);
   EXPECT_EQ(Array::geometry_type, expected_geometry_type);
   EXPECT_EQ(Array::dimensions, expected_dimensions);
+
+  constexpr enum GeoArrowType type_id = geoarrow::type_traits::GeometryTypeTraits<
+      Array::geometry_type, Array::dimensions>::type_id(GEOARROW_COORD_TYPE_SEPARATE);
+  using type_traits = geoarrow::type_traits::TypeTraits<type_id>;
+  EXPECT_EQ(type_traits::geometry_type, expected_geometry_type);
+  EXPECT_EQ(type_traits::dimensions, expected_dimensions);
+  EXPECT_EQ(type_traits::coord_type_id, GEOARROW_COORD_TYPE_SEPARATE);
+
+  constexpr enum GeoArrowType type_id_interleaved =
+      geoarrow::type_traits::GeometryTypeTraits<Array::geometry_type, Array::dimensions>::
+          type_id(GEOARROW_COORD_TYPE_INTERLEAVED);
+  using type_traits_interleaved = geoarrow::type_traits::TypeTraits<type_id_interleaved>;
+  EXPECT_EQ(type_traits_interleaved::geometry_type, expected_geometry_type);
+  EXPECT_EQ(type_traits_interleaved::dimensions, expected_dimensions);
+  EXPECT_EQ(type_traits_interleaved::coord_type_id, GEOARROW_COORD_TYPE_INTERLEAVED);
+
   *was_called = true;
 }
 

--- a/src/geoarrow/hpp/geometry_type_traits_test.cc
+++ b/src/geoarrow/hpp/geometry_type_traits_test.cc
@@ -1,0 +1,17 @@
+
+
+#include <gtest/gtest.h>
+
+#include "nanoarrow/nanoarrow.h"
+
+#include "geoarrow.hpp"
+#include "geometry_type_traits.hpp"
+
+namespace geoarrow::type_traits {
+
+TEST(GeoArrowHppTest, GeometryTypeTraits) {
+  using array_type = typename TypeTraits<GEOARROW_TYPE_POINT>::array_type;
+  ASSERT_EQ(array_type::geometry_type, GEOARROW_GEOMETRY_TYPE_POINT);
+}
+
+}  // namespace geoarrow::type_traits

--- a/src/geoarrow/hpp/geometry_type_traits_test.cc
+++ b/src/geoarrow/hpp/geometry_type_traits_test.cc
@@ -8,14 +8,33 @@
 #include "geometry_type_traits.hpp"
 
 template <typename Array>
-void DoSomethingWithArray(const Array& array, bool* was_called = nullptr) {
+void DoSomethingWithArray(const Array& array, bool* was_called,
+                          enum GeoArrowGeometryType expected_geometry_type,
+                          enum GeoArrowDimensions expected_dimensions) {
   EXPECT_EQ(array.value.size(), 0);
+  EXPECT_EQ(Array::geometry_type, expected_geometry_type);
+  EXPECT_EQ(Array::dimensions, expected_dimensions);
   *was_called = true;
 }
 
 TEST(GeoArrowHppTest, DispatchNativeArray) {
-  bool was_called = false;
-  GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(GEOARROW_TYPE_POINT, DoSomethingWithArray,
-                                      &was_called);
-  EXPECT_TRUE(was_called);
+  enum GeoArrowGeometryType all_geometry_types[] = {
+      GEOARROW_GEOMETRY_TYPE_POINT,           GEOARROW_GEOMETRY_TYPE_LINESTRING,
+      GEOARROW_GEOMETRY_TYPE_POLYGON,         GEOARROW_GEOMETRY_TYPE_MULTIPOINT,
+      GEOARROW_GEOMETRY_TYPE_MULTILINESTRING, GEOARROW_GEOMETRY_TYPE_MULTIPOLYGON};
+  enum GeoArrowDimensions all_dimensions[] = {
+      GEOARROW_DIMENSIONS_XY, GEOARROW_DIMENSIONS_XYZ, GEOARROW_DIMENSIONS_XYM,
+      GEOARROW_DIMENSIONS_XYZM};
+
+  for (auto geometry_type : all_geometry_types) {
+    for (auto dimensions : all_dimensions) {
+      SCOPED_TRACE(std::string(GeoArrowGeometryTypeString(geometry_type)) + " / " +
+                   GeoArrowDimensionsString(dimensions));
+      bool was_called = false;
+      enum GeoArrowType type_id =
+          GeoArrowMakeType(geometry_type, dimensions, GEOARROW_COORD_TYPE_SEPARATE);
+      GEOARROW_DISPATCH_NATIVE_ARRAY_CALL(type_id, DoSomethingWithArray, &was_called,
+                                          geometry_type, dimensions);
+    }
+  }
 }

--- a/src/geoarrow/hpp/wkb_util.hpp
+++ b/src/geoarrow/hpp/wkb_util.hpp
@@ -1,6 +1,6 @@
 
-#ifndef GEOARROW_HPP_BINARY_UTIL_INCLUDED
-#define GEOARROW_HPP_BINARY_UTIL_INCLUDED
+#ifndef GEOARROW_HPP_wkb_util_INCLUDED
+#define GEOARROW_HPP_wkb_util_INCLUDED
 
 #include <vector>
 
@@ -20,7 +20,7 @@
 
 namespace geoarrow {
 
-namespace binary_util {
+namespace wkb_util {
 
 namespace internal {
 
@@ -602,7 +602,7 @@ struct WKBArray : public array_util::Array<WKBBlobSequence<Offset>> {
   }
 };
 
-}  // namespace binary_util
+}  // namespace wkb_util
 
 }  // namespace geoarrow
 

--- a/src/geoarrow/hpp/wkb_util.hpp
+++ b/src/geoarrow/hpp/wkb_util.hpp
@@ -1,6 +1,6 @@
 
-#ifndef GEOARROW_HPP_wkb_util_INCLUDED
-#define GEOARROW_HPP_wkb_util_INCLUDED
+#ifndef GEOARROW_HPP_WKB_UTIL_INCLUDED
+#define GEOARROW_HPP_WKB_UTIL_INCLUDED
 
 #include <vector>
 

--- a/src/geoarrow/hpp/wkb_util_test.cc
+++ b/src/geoarrow/hpp/wkb_util_test.cc
@@ -7,8 +7,8 @@
 
 #include "wkx_testing.hpp"
 
-using geoarrow::binary_util::WKBGeometry;
-using geoarrow::binary_util::WKBParser;
+using geoarrow::wkb_util::WKBGeometry;
+using geoarrow::wkb_util::WKBParser;
 using XY = geoarrow::array_util::XY<double>;
 using XYZ = geoarrow::array_util::XYZ<double>;
 using XYM = geoarrow::array_util::XYM<double>;
@@ -29,7 +29,7 @@ TEST(GeoArrowHppTest, ValidWKBArray) {
   geoarrow::ArrayReader reader(GEOARROW_TYPE_WKB);
   reader.SetArray(&array_feat);
 
-  geoarrow::binary_util::WKBArray<int32_t> array;
+  geoarrow::wkb_util::WKBArray<int32_t> array;
   array.Init(reader.View().array_view());
 
   WKBGeometry geometry;


### PR DESCRIPTION
This PR makes it possible to write code against (compile-time) resolved Array classes

```c
using BoxXYZM = geoarrow::array_util::BoxXYZM<double>;
using XYZM = BoxXYZM::bound_type;

template <typename Array>
void GenericBoundsXYZM(Array& array, const struct GeoArrowArrayView* array_view,
                       BoxXYZM* out) {
  array.Init(array_view);
  BoxXYZM bounds = *out;

  array.template VisitVertices<XYZM>([&](XYZM xyzm) {
    for (size_t i = 0; i < xyzm.size(); i++) {
      bounds[i] = std::min(bounds[i], xyzm[i]);
      bounds[xyzm.size() + i] = std::max(bounds[xyzm.size() + i], xyzm[i]);
    }
  });

  *out = bounds;
}
```

...followed by something like:

```c
GEOARROW_DISPATCH_ARRAY_CALL(type_id, GenericBoundsXYZM, reader.View().array_view(),
                                 &bounds);
```

...which instantiates all the necessary templates. Probably this is instantiating more templates than strictly needed (we can probably get it down to 6 (one per geometry type) from 24 (one per geometry type per dimension). For XY-only iteration, the XY versions of the arrays can be initialized with all the other dimension types.