### PR TITLE
feat: Add `const ArrowArray` overload for `ArrayReader::SetArray()`

### DIFF
--- a/src/geoarrow/hpp/array_reader.hpp
+++ b/src/geoarrow/hpp/array_reader.hpp
@@ -46,10 +46,14 @@ class ArrayReader {
   }
 
   void SetArray(struct ArrowArray* array) {
-    struct GeoArrowError error {};
-    GEOARROW_THROW_NOT_OK(&error, GeoArrowArrayReaderSetArray(&reader_, array, &error));
     std::memcpy(&array_.array, array, sizeof(struct ArrowArray));
     array->release = nullptr;
+    SetArrayNonOwning(&array_.array);
+  }
+
+  void SetArrayNonOwning(const struct ArrowArray* array) {
+    struct GeoArrowError error {};
+    GEOARROW_THROW_NOT_OK(&error, GeoArrowArrayReaderSetArray(&reader_, array, &error));
   }
 
   GeoArrowErrorCode Visit(struct GeoArrowVisitor* visitor, int64_t offset, int64_t length,


### PR DESCRIPTION
The non-const ownership-taking version is great, but libraries that don't have to give up ownership can use the interface more effectively if we expose not taking ownership (e.g., to present a view of some existing structure).