### PR TITLE
chore: Add GeoArrowGeometry to benchmarks

### DIFF
--- a/dev/benchmarks/c/wkb_bounding_benchmark.cc
+++ b/dev/benchmarks/c/wkb_bounding_benchmark.cc
@@ -1,5 +1,4 @@
 
-
 #include <cstdint>
 #include <iostream>
 #include <sstream>
@@ -148,6 +147,83 @@ void BenchBoundWKBPointsUsingGeoArrowHpp(benchmark::State& state) {
   CheckResult(bounds);
 }
 
+BoxXY BoundWKBLinestringUsingNewGeoArrowHpp(const std::vector<uint8_t>& wkb) {
+  BoxXY bounds = BoxXY::Empty();
+
+  GeoArrowGeometry geometry;
+  geoarrow::geometry::WKBParser parser;
+  if (parser.Parse(wkb.data(), wkb.size(), &geometry) != parser.OK) {
+    throw std::runtime_error("Error parsing WKB");
+  }
+
+  VisitVertices(geometry.data(), [&](XY xy) {
+    bounds[0] = MIN(bounds[0], xy.x());
+    bounds[1] = MIN(bounds[1], xy.y());
+    bounds[2] = MAX(bounds[2], xy.x());
+    bounds[3] = MAX(bounds[3], xy.y());
+  });
+
+  return bounds;
+}
+
+void BenchBoundWKBLinestringUsingNewGeoArrowHpp(benchmark::State& state) {
+  std::vector<double> coords = MakeInterleavedCoords(kNumCoordsPrettyBig);
+  std::vector<uint8_t> wkb = MakeLinestringWKB(coords);
+  BoxXY bounds{};
+
+  for (auto _ : state) {
+    bounds = BoundWKBLinestringUsingNewGeoArrowHpp(wkb);
+    benchmark::DoNotOptimize(bounds);
+  }
+
+  state.SetItemsProcessed(kNumCoordsPrettyBig * state.iterations());
+  CheckResult(bounds);
+}
+
+BoxXY BoundWKBPointsUsingNewGeoArrowHpp(const std::vector<uint8_t>& wkb,
+                                        uint32_t num_points) {
+  uint32_t xy_point_bytes = 21;
+  if (wkb.size() != (num_points * xy_point_bytes)) {
+    throw std::runtime_error("Expected " + std::to_string(num_points * xy_point_bytes) +
+                             " bytes but got " + std::to_string(wkb.size()));
+  }
+
+  BoxXY bounds = BoxXY::Empty();
+
+  geoarrow::geometry::Geometry geometry;
+  geoarrow::geometry::WKBParser parser;
+
+  for (uint32_t i = 0; i < num_points; i++) {
+    if (parser.Parse(wkb.data() + (i * xy_point_bytes), xy_point_bytes, &geometry) !=
+        parser.OK) {
+      throw std::runtime_error("Error parsing WKB at index " + std::to_string(i));
+    }
+
+    VisitVertices(geometry.data(), [&](XY xy) {
+      bounds[0] = MIN(bounds[0], xy.x());
+      bounds[1] = MIN(bounds[1], xy.y());
+      bounds[2] = MAX(bounds[2], xy.x());
+      bounds[3] = MAX(bounds[3], xy.y());
+    });
+  }
+
+  return bounds;
+}
+
+void BenchBoundWKBPointsUsingNewGeoArrowHpp(benchmark::State& state) {
+  std::vector<double> coords = MakeInterleavedCoords(kNumCoordsPrettyBig);
+  std::vector<uint8_t> wkb = MakePointsWKB(coords);
+  BoxXY bounds{};
+
+  for (auto _ : state) {
+    bounds = BoundWKBPointsUsingNewGeoArrowHpp(wkb, kNumCoordsPrettyBig);
+    benchmark::DoNotOptimize(bounds);
+  }
+
+  state.SetItemsProcessed(kNumCoordsPrettyBig * state.iterations());
+  CheckResult(bounds);
+}
+
 BoxXY BoundWKBPointsUsingUnalignedSequence(const std::vector<uint8_t>& wkb,
                                            uint32_t num_points) {
   uint32_t xy_point_bytes = 21;
@@ -212,6 +288,8 @@ void BenchBoundWKBPointsUsingUnalignedSequence(benchmark::State& state) {
 BENCHMARK(BenchBoundDoubles);
 BENCHMARK(BenchBoundWKBLinestringUsingGeoArrowHpp);
 BENCHMARK(BenchBoundWKBPointsUsingGeoArrowHpp);
+BENCHMARK(BenchBoundWKBPointsUsingNewGeoArrowHpp);
+BENCHMARK(BenchBoundWKBLinestringUsingNewGeoArrowHpp);
 BENCHMARK(BenchBoundWKBPointsUsingUnalignedSequence);
 
 std::vector<double> MakeInterleavedCoords(uint32_t num_coords) {


### PR DESCRIPTION
This PR adds benchmarks for iterating over WKB end members using the new GeoArrowWKBReader + Geometry.

```
----------------------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------------------------
BenchBoundDoubles                             891823 ns       891731 ns          783 items_per_second=1.12142G/s
BenchBoundWKBLinestringUsingGeoArrowHpp       903941 ns       903838 ns          773 items_per_second=1.10639G/s
BenchBoundWKBPointsUsingGeoArrowHpp          6257939 ns      6256452 ns          115 items_per_second=159.835M/s
BenchBoundWKBLinestringUsingWkbReader         910538 ns       910043 ns          746 items_per_second=1.09885G/s
BenchBoundWKBPointsUsingWkbReader            6048103 ns      6046551 ns          118 items_per_second=165.384M/s
BenchBoundWKBPointsUsingUnalignedSequence     889149 ns       889019 ns          803 items_per_second=1.12484G/s
```