### PR TITLE
feat: Add new edge types in GeoArrow 0.2 spec to C library

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Install coverage dependencies
         run: |
           sudo apt-get install -y lcov
-          pip install pytest-cov Cython
+          pip install pytest-cov "Cython < 3.1.0"
 
       - name: Install editable
         run: |
@@ -51,7 +51,7 @@ jobs:
       - name: Coverage (geoarrow-c)
         if: success() && matrix.python-version == '3.13'
         run: |
-          pip install setuptools Cython
+          pip install setuptools "Cython < 3.1.0"
 
           pushd python/geoarrow-c
 

--- a/python/geoarrow-c/pyproject.toml
+++ b/python/geoarrow-c/pyproject.toml
@@ -36,7 +36,8 @@ repository = "https://github.com/geoarrow/geoarrow-c"
 requires = [
     "setuptools >= 61.0.0",
     "setuptools-scm",
-    "Cython"
+    # Something about cpdef changed here
+    "Cython < 3.1.0"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/python/geoarrow-c/setup.py
+++ b/python/geoarrow-c/setup.py
@@ -52,14 +52,14 @@ sources += [
 
 
 # Workaround because setuptools has no easy way to mix C and C++ sources
-# if extra flags are required (e.g., -std=c++11 like we need here).
+# if extra flags are required (e.g., -std=c++17 like we need here).
 class build_ext_subclass(build_ext):
     def build_extensions(self):
         original__compile = self.compiler._compile
 
         def new__compile(obj, src, ext, cc_args, extra_postargs, pp_opts):
             if src.endswith(".c"):
-                extra_postargs = [s for s in extra_postargs if s != "-std=c++11"]
+                extra_postargs = [s for s in extra_postargs if s != "-std=c++17"]
             return original__compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
 
         self.compiler._compile = new__compile
@@ -94,7 +94,7 @@ setup(
             ],
             language="c++",
             sources=["src/geoarrow/c/_lib.pyx"] + sources,
-            extra_compile_args=["-std=c++11"] + extra_compile_args,
+            extra_compile_args=["-std=c++17"] + extra_compile_args,
             extra_link_args=[] + extra_link_args,
             define_macros=[
                 ("GEOARROW_NAMESPACE", "GeoArrowPythonPkg"),

--- a/python/geoarrow-c/src/geoarrow/c/_lib.pyx
+++ b/python/geoarrow-c/src/geoarrow/c/_lib.pyx
@@ -120,6 +120,10 @@ cdef extern from "geoarrow_type.h":
     cpdef enum GeoArrowEdgeType:
         GEOARROW_EDGE_TYPE_PLANAR
         GEOARROW_EDGE_TYPE_SPHERICAL
+        GEOARROW_EDGE_TYPE_VINCENTY
+        GEOARROW_EDGE_TYPE_THOMAS
+        GEOARROW_EDGE_TYPE_ANDOYER
+        GEOARROW_EDGE_TYPE_KARNEY
 
     cpdef enum GeoArrowCrsType:
         GEOARROW_CRS_TYPE_NONE

--- a/python/geoarrow-c/src/geoarrow/c/lib.py
+++ b/python/geoarrow-c/src/geoarrow/c/lib.py
@@ -103,6 +103,14 @@ class EdgeType:
     PLANAR = _lib.GEOARROW_EDGE_TYPE_PLANAR
     #: Edges are geodesic on a sphere
     SPHERICAL = _lib.GEOARROW_EDGE_TYPE_SPHERICAL
+    #: Edges are geodesic on a spheroid according to the Vincenty algorithm
+    VINCENTY = _lib.GEOARROW_EDGE_TYPE_VINCENTY
+    #: Edges are geodesic on a spheroid according to the Thomas algorithm
+    THOMAS = _lib.GEOARROW_EDGE_TYPE_THOMAS
+    #: Edges are geodesic on a spheroid according to the Andoyer algorithm
+    ANDOYER = _lib.GEOARROW_EDGE_TYPE_ANDOYER
+    #: Edges are geodesic on a spheroid according to the Karney algorithm
+    KARNEY = _lib.GEOARROW_EDGE_TYPE_KARNEY
 
 
 class CrsType:

--- a/src/geoarrow/geoarrow_type.h
+++ b/src/geoarrow/geoarrow_type.h
@@ -264,7 +264,14 @@ enum GeoArrowCoordType {
 
 /// \brief Edge types/interpolations supported by GeoArrow
 /// \ingroup geoarrow-schema
-enum GeoArrowEdgeType { GEOARROW_EDGE_TYPE_PLANAR, GEOARROW_EDGE_TYPE_SPHERICAL };
+enum GeoArrowEdgeType {
+  GEOARROW_EDGE_TYPE_PLANAR,
+  GEOARROW_EDGE_TYPE_SPHERICAL,
+  GEOARROW_EDGE_TYPE_VINCENTY,
+  GEOARROW_EDGE_TYPE_THOMAS,
+  GEOARROW_EDGE_TYPE_ANDOYER,
+  GEOARROW_EDGE_TYPE_KARNEY
+};
 
 /// \brief Coordinate reference system types supported by GeoArrow
 /// \ingroup geoarrow-schema

--- a/src/geoarrow/geoarrow_type_inline.h
+++ b/src/geoarrow/geoarrow_type_inline.h
@@ -120,6 +120,14 @@ static inline const char* GeoArrowEdgeTypeString(enum GeoArrowEdgeType edge_type
       return "planar";
     case GEOARROW_EDGE_TYPE_SPHERICAL:
       return "spherical";
+    case GEOARROW_EDGE_TYPE_VINCENTY:
+      return "vincenty";
+    case GEOARROW_EDGE_TYPE_THOMAS:
+      return "thomas";
+    case GEOARROW_EDGE_TYPE_ANDOYER:
+      return "andoyer";
+    case GEOARROW_EDGE_TYPE_KARNEY:
+      return "karney";
     default:
       return "<not valid>";
   }

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -220,6 +220,14 @@ static GeoArrowErrorCode ParseJSONMetadata(struct GeoArrowMetadataView* metadata
         metadata_view->edge_type = GEOARROW_EDGE_TYPE_SPHERICAL;
       } else if (v.size_bytes == 8 && strncmp(v.data, "\"planar\"", 8) == 0) {
         metadata_view->edge_type = GEOARROW_EDGE_TYPE_PLANAR;
+      } else if (v.size_bytes == 10 && strncmp(v.data, "\"vincenty\"", 10) == 0) {
+        metadata_view->edge_type = GEOARROW_EDGE_TYPE_VINCENTY;
+      } else if (v.size_bytes == 8 && strncmp(v.data, "\"thomas\"", 8) == 0) {
+        metadata_view->edge_type = GEOARROW_EDGE_TYPE_THOMAS;
+      } else if (v.size_bytes == 9 && strncmp(v.data, "\"andoyer\"", 9) == 0) {
+        metadata_view->edge_type = GEOARROW_EDGE_TYPE_ANDOYER;
+      } else if (v.size_bytes == 8 && strncmp(v.data, "\"karney\"", 8) == 0) {
+        metadata_view->edge_type = GEOARROW_EDGE_TYPE_KARNEY;
       } else if (v.data[0] == 'n') {
         metadata_view->edge_type = GEOARROW_EDGE_TYPE_PLANAR;
       } else {

--- a/src/geoarrow/metadata.c
+++ b/src/geoarrow/metadata.c
@@ -478,6 +478,7 @@ static GeoArrowErrorCode GeoArrowSchemaSetMetadataInternal(
 
   int64_t chars_written = GeoArrowMetadataSerializeInternal(metadata_view, metadata);
   NANOARROW_DCHECK(chars_written == metadata_size);
+  NANOARROW_UNUSED(chars_written);
 
   struct ArrowBuffer existing_buffer;
   int result = ArrowMetadataBuilderInit(&existing_buffer, schema->metadata);

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -75,8 +75,8 @@ void TestMetadata(const std::string& json, enum GeoArrowEdgeType edge_type,
                   enum GeoArrowCrsType crs_type, const std::string& crs) {
   SCOPED_TRACE(json + " => " + GeoArrowEdgeTypeString(edge_type) + "/" +
                GeoArrowCrsTypeString(crs_type) + "/'" + crs + "'");
-  struct GeoArrowError error{};
-  struct GeoArrowMetadataView metadata_view{};
+  struct GeoArrowError error {};
+  struct GeoArrowMetadataView metadata_view {};
 
   struct GeoArrowStringView metadata;
   metadata.data = json.data();
@@ -90,8 +90,8 @@ void TestMetadata(const std::string& json, enum GeoArrowEdgeType edge_type,
 }
 
 void TestMetadataError(const std::string& json, int code) {
-  struct GeoArrowError error{};
-  struct GeoArrowMetadataView metadata_view{};
+  struct GeoArrowError error {};
+  struct GeoArrowMetadataView metadata_view {};
 
   struct GeoArrowStringView metadata;
   metadata.data = json.data();
@@ -311,7 +311,7 @@ TEST(MetadataTest, MetadataTestUnescapeCRS) {
 }
 
 TEST(MetadataTest, MetadataTestCRSLonLat) {
-  struct GeoArrowMetadataView metadata_view{};
+  struct GeoArrowMetadataView metadata_view {};
   GeoArrowMetadataSetLonLat(&metadata_view);
   EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_PROJJSON);
   ASSERT_EQ(metadata_view.crs.size_bytes, 1255);
@@ -321,7 +321,7 @@ TEST(MetadataTest, MetadataTestCRSLonLat) {
   GeoArrowMetadataSerialize(&metadata_view, metadata.data(), metadata_size);
 
   // Make sure we can serialize + deserialize a big complex nested CRS value
-  struct GeoArrowMetadataView metadata_view2{};
+  struct GeoArrowMetadataView metadata_view2 {};
   ASSERT_EQ(GeoArrowMetadataViewInit(
                 &metadata_view2, {metadata.data(), static_cast<int64_t>(metadata.size())},
                 nullptr),

--- a/src/geoarrow/metadata_test.cc
+++ b/src/geoarrow/metadata_test.cc
@@ -75,8 +75,8 @@ void TestMetadata(const std::string& json, enum GeoArrowEdgeType edge_type,
                   enum GeoArrowCrsType crs_type, const std::string& crs) {
   SCOPED_TRACE(json + " => " + GeoArrowEdgeTypeString(edge_type) + "/" +
                GeoArrowCrsTypeString(crs_type) + "/'" + crs + "'");
-  struct GeoArrowError error {};
-  struct GeoArrowMetadataView metadata_view {};
+  struct GeoArrowError error{};
+  struct GeoArrowMetadataView metadata_view{};
 
   struct GeoArrowStringView metadata;
   metadata.data = json.data();
@@ -90,8 +90,8 @@ void TestMetadata(const std::string& json, enum GeoArrowEdgeType edge_type,
 }
 
 void TestMetadataError(const std::string& json, int code) {
-  struct GeoArrowError error {};
-  struct GeoArrowMetadataView metadata_view {};
+  struct GeoArrowError error{};
+  struct GeoArrowMetadataView metadata_view{};
 
   struct GeoArrowStringView metadata;
   metadata.data = json.data();
@@ -102,21 +102,25 @@ void TestMetadataError(const std::string& json, int code) {
 }
 
 TEST(MetadataTest, MetadataTestReadJSONEdges) {
+  // Default
   EXPECT_NO_FATAL_FAILURE(
-      // Default
       TestMetadata(R"({})", GEOARROW_EDGE_TYPE_PLANAR, GEOARROW_CRS_TYPE_NONE, ""));
-  EXPECT_NO_FATAL_FAILURE(
-      // Explicit planar
-      TestMetadata(R"({"edges": "planar"})", GEOARROW_EDGE_TYPE_PLANAR,
-                   GEOARROW_CRS_TYPE_NONE, ""));
-  EXPECT_NO_FATAL_FAILURE(
-      // Explicit spherical
-      TestMetadata(R"({"edges": "spherical"})", GEOARROW_EDGE_TYPE_SPHERICAL,
-                   GEOARROW_CRS_TYPE_NONE, ""));
-  EXPECT_NO_FATAL_FAILURE(
-      // Explicit spherical
-      TestMetadata(R"({"edges": "spherical"})", GEOARROW_EDGE_TYPE_SPHERICAL,
-                   GEOARROW_CRS_TYPE_NONE, ""));
+
+  // Explicit
+  EXPECT_NO_FATAL_FAILURE(TestMetadata(
+      R"({"edges": "planar"})", GEOARROW_EDGE_TYPE_PLANAR, GEOARROW_CRS_TYPE_NONE, ""));
+  EXPECT_NO_FATAL_FAILURE(TestMetadata(R"({"edges": "spherical"})",
+                                       GEOARROW_EDGE_TYPE_SPHERICAL,
+                                       GEOARROW_CRS_TYPE_NONE, ""));
+  EXPECT_NO_FATAL_FAILURE(TestMetadata(R"({"edges": "vincenty"})",
+                                       GEOARROW_EDGE_TYPE_VINCENTY,
+                                       GEOARROW_CRS_TYPE_NONE, ""));
+  EXPECT_NO_FATAL_FAILURE(TestMetadata(
+      R"({"edges": "thomas"})", GEOARROW_EDGE_TYPE_THOMAS, GEOARROW_CRS_TYPE_NONE, ""));
+  EXPECT_NO_FATAL_FAILURE(TestMetadata(
+      R"({"edges": "andoyer"})", GEOARROW_EDGE_TYPE_ANDOYER, GEOARROW_CRS_TYPE_NONE, ""));
+  EXPECT_NO_FATAL_FAILURE(TestMetadata(
+      R"({"edges": "karney"})", GEOARROW_EDGE_TYPE_KARNEY, GEOARROW_CRS_TYPE_NONE, ""));
 
   // Non-string JSON type
   EXPECT_NO_FATAL_FAILURE(TestMetadataError(R"({"edges": {}})", EINVAL));
@@ -307,7 +311,7 @@ TEST(MetadataTest, MetadataTestUnescapeCRS) {
 }
 
 TEST(MetadataTest, MetadataTestCRSLonLat) {
-  struct GeoArrowMetadataView metadata_view {};
+  struct GeoArrowMetadataView metadata_view{};
   GeoArrowMetadataSetLonLat(&metadata_view);
   EXPECT_EQ(metadata_view.crs_type, GEOARROW_CRS_TYPE_PROJJSON);
   ASSERT_EQ(metadata_view.crs.size_bytes, 1255);
@@ -317,7 +321,7 @@ TEST(MetadataTest, MetadataTestCRSLonLat) {
   GeoArrowMetadataSerialize(&metadata_view, metadata.data(), metadata_size);
 
   // Make sure we can serialize + deserialize a big complex nested CRS value
-  struct GeoArrowMetadataView metadata_view2 {};
+  struct GeoArrowMetadataView metadata_view2{};
   ASSERT_EQ(GeoArrowMetadataViewInit(
                 &metadata_view2, {metadata.data(), static_cast<int64_t>(metadata.size())},
                 nullptr),


### PR DESCRIPTION
Adds the new edge types to the accepted list to ensure these don't error when passed to the parser and can roundtrip.

Also pins the Cython version for now...it's likely we'll move to nanobind rather than update the bindings for this for the next release.