### PR TITLE
fix: Ensure large/view types can be used as input to kernels

### DIFF
--- a/src/geoarrow/builder.c
+++ b/src/geoarrow/builder.c
@@ -223,7 +223,7 @@ GeoArrowErrorCode GeoArrowBuilderFinish(struct GeoArrowBuilder* builder,
       break;
 
     default:
-      return EINVAL;
+      break;
   }
 
   // If the validity bitmap was used, we need to update the validity buffer size

--- a/src/geoarrow/kernel.c
+++ b/src/geoarrow/kernel.c
@@ -237,10 +237,6 @@ static int kernel_visitor_start(struct GeoArrowKernel* kernel, struct ArrowSchem
 
   switch (schema_view.type) {
     case GEOARROW_TYPE_UNINITIALIZED:
-    case GEOARROW_TYPE_LARGE_WKB:
-    case GEOARROW_TYPE_LARGE_WKT:
-    case GEOARROW_TYPE_WKB_VIEW:
-    case GEOARROW_TYPE_WKT_VIEW:
       return EINVAL;
     default:
       NANOARROW_RETURN_NOT_OK(


### PR DESCRIPTION
There were a few checks that prevented large/view types from being used in the kernels (even though the underlying reader supported them).