### PR TITLE
fix: Ensure we reutrn a value for the unreachable case

### DIFF
--- a/src/geoarrow/native_writer.c
+++ b/src/geoarrow/native_writer.c
@@ -186,6 +186,7 @@ static GeoArrowErrorCode GeoArrowNativeWriterAppendEmpty(
       return NANOARROW_OK;
     default:
       NANOARROW_DCHECK(0 && "unreachable");
+      return EINVAL;
   }
 }
 


### PR DESCRIPTION
In release mode we had a function that would fail to return in an unreachable case (which caused compile failures)